### PR TITLE
Channels implementation with new listeners

### DIFF
--- a/shared/src/main/scala/async/Async.scala
+++ b/shared/src/main/scala/async/Async.scala
@@ -137,7 +137,7 @@ object Async:
       import scala.collection.JavaConverters._
       val q = java.util.concurrent.ConcurrentLinkedQueue[T]()
       q.addAll(values.asJavaCollection)
-      new Source[T]: 
+      new Source[T]:
         override def poll(k: Listener[T]): Boolean =
           if q.isEmpty() then return false
           else
@@ -174,25 +174,35 @@ object Async:
         def dropListener(k: Listener[U]): Unit =
           src.dropListener(transform(k))
 
+  def race[T](sources: Source[T]*) = raceImpl[T, T]((v, _) => v)(sources*)
+  def raceWithOrigin[T](sources: Source[T]*) =
+    raceImpl[(T, Source[T]), T]((v, src) => (v, src))(sources*)
+
   /** Pass first result from any of `sources` to the continuation */
-  def race[T](sources: Source[T]*): Source[T] =
+  private def raceImpl[T, U](map: (U, Source[U]) => T)(sources: Source[U]*): Source[T] =
     new Source[T] { selfSrc =>
       def poll(k: Listener[T]): Boolean =
         val it = sources.iterator
         var found = false
 
-        while it.hasNext && !found do found = it.next.poll(k)
+        while it.hasNext && !found do
+          found = it.next.poll(
+            new Listener.ForwardingListener[U](this, k):
+              val lock = withLock(k) { inner => new ListenerLockWrapper(inner, selfSrc) }
+              def complete(data: U, source: Async.Source[U]) =
+                k.complete(map(data, source), selfSrc)
+          )
         found
 
       def onComplete(k: Listener[T]): Unit =
-        val listener = new Listener.ForwardingListener[T](this, k)
+        val listener = new Listener.ForwardingListener[U](this, k)
           with NumberedLock
           with Listener.ListenerLock
           with Listener.PartialLock { self =>
           val lock = self
 
           var found = false
-          inline def heldLock = if k.lock == null then Listener.Locked else this
+          def heldLock = if k.lock == null then Listener.Locked else this
 
           /* == PartialLock implementation == */
           // Note that this is bogus if k.lock is null, but we'll never use it if it is.
@@ -219,21 +229,47 @@ object Async:
             self.releaseLock()
             if until == heldLock then null else k.lock
 
-          def complete(item: T, src: Async.Source[T]) =
+          def complete(item: U, src: Async.Source[U]) =
             found = true
             self.releaseLock()
             sources.foreach(s => if s != src then s.dropListener(self))
-            k.complete(item, selfSrc)
+            k.complete(map(item, src), selfSrc)
         } // end listener
 
         sources.foreach(_.onComplete(listener))
 
       def dropListener(k: Listener[T]): Unit =
-        val listener = Listener.ForwardingListener.empty(this, k)
+        val listener = Listener.ForwardingListener.empty[U](this, k)
         sources.foreach(_.dropListener(listener))
 
     }
-  end race
+  end raceImpl
+
+  /** Cases for handling async sources in a [[select]]. [[SelectCase]] can be constructed by extension methods `handle`
+    * and `handleVal` of [[Source]].
+    */
+  opaque type SelectCase[T] = (Source[?], Nothing => T)
+  //                           ^ unsafe types, but we only construct SelectCase from `handle` and `handleVal` which are safe
+
+  extension [T](src: Source[T])
+    /** Attach a handler to [[src]], creating a [[SelectCase]]. */
+    inline def handle[U](f: T => U): SelectCase[U] = (src, f)
+
+    inline def ~~>[U](f: T => U): SelectCase[U] = src.handle(f)
+
+    // /** Attach a handler to [[src]] that takes a [[T]] and throws if [[Failure]] was returned from the source, creating
+    //   * a [[SelectCase]].
+    //   */
+    // inline def handleVal[U](f: T => U): SelectCase[U] = (src, t => f(t.get))
+
+  /** Race a list of sources with the corresponding handler functions, once an item has come back. Like [[race]],
+    * [[select]] guarantees exactly one of the sources are polled. Unlike `map`ping a [[Source]], the handler in
+    * [[select]] is run in the same async context as the calling context of [[select]].
+    */
+  def select[T](cases: SelectCase[T]*)(using Async) =
+    val (input, which) = raceWithOrigin(cases.map(_._1)*).await
+    val (_, handler) = cases.find(_._1 == which).get
+    handler.asInstanceOf[input.type => T](input)
 
   /** If left (respectively, right) source succeeds with `x`, pass `Left(x)`, (respectively, Right(x)) on to the
     * continuation.

--- a/shared/src/main/scala/async/Async.scala
+++ b/shared/src/main/scala/async/Async.scala
@@ -112,6 +112,9 @@ object Async:
       poll(Listener.acceptingListener { (x, _) => resultOpt = Some(x) })
       resultOpt
 
+    /** Utility method for direct waiting with `Async`. */
+    def await(using Async) = Async.await(this)
+
   end Source
 
   /** An original source has a standard definition of `onComplete` in terms of `poll` and `addListener`. Implementations

--- a/shared/src/main/scala/async/Async.scala
+++ b/shared/src/main/scala/async/Async.scala
@@ -190,8 +190,7 @@ object Async:
             k.complete(map(data, source), selfSrc)
         end listener
 
-        while it.hasNext && !found do
-          found = it.next.poll(listener)
+        while it.hasNext && !found do found = it.next.poll(listener)
         found
 
       def onComplete(k: Listener[T]): Unit =
@@ -245,8 +244,8 @@ object Async:
     }
   end raceImpl
 
-  /** Cases for handling async sources in a [[select]]. [[SelectCase]] can be
-   *  constructed by extension methods `handle` of [[Source]].
+  /** Cases for handling async sources in a [[select]]. [[SelectCase]] can be constructed by extension methods `handle`
+    * of [[Source]].
     */
   opaque type SelectCase[T] = (Source[?], Nothing => T)
   //                           ^ unsafe types, but we only construct SelectCase from `handle` which is safe

--- a/shared/src/main/scala/async/Listener.scala
+++ b/shared/src/main/scala/async/Listener.scala
@@ -64,11 +64,11 @@ object Listener:
     * [[Async.Source.dropListener]] these listeners are compared for equality by the hash of the source and the inner
     * listener.
     */
-  abstract case class ForwardingListener[T](src: Async.Source[?], inner: Listener[T]) extends Listener[T]
+  abstract case class ForwardingListener[T](src: Async.Source[?], inner: Listener[?]) extends Listener[T]
 
   object ForwardingListener:
     /** Create an empty [[ForwardingListener]] for equality comparison. */
-    def empty[T](src: Async.Source[?], inner: Listener[T]) = new ForwardingListener(src, inner):
+    def empty[T](src: Async.Source[?], inner: Listener[?]) = new ForwardingListener[T](src, inner):
       val lock = null
       override def complete(data: T, source: Async.Source[T]) = ???
 

--- a/shared/src/main/scala/async/Timer.scala
+++ b/shared/src/main/scala/async/Timer.scala
@@ -49,7 +49,7 @@ class Timer(tickDuration: Duration) extends Cancellable {
   inline final def src: Async.Source[this.TimerEvent] = Source
 
   /** Starts the timer. Suspends until the timer is cancelled. */
-  def start()(using Async, AsyncOperations): Unit =
+  def run()(using Async, AsyncOperations): Unit =
     cancellationScope(this):
       loop()
 

--- a/shared/src/main/scala/async/channels.scala
+++ b/shared/src/main/scala/async/channels.scala
@@ -89,9 +89,9 @@ class ChannelClosedException extends Exception
 private val channelClosedException = ChannelClosedException()
 
 object SyncChannel:
-  def apply[T]()(using SuspendSupport): SyncChannel[T] = Impl()
+  def apply[T](): SyncChannel[T] = Impl()
 
-  private class Impl[T](using suspend: SuspendSupport) extends Channel.Impl[T] with SyncChannel[T]:
+  private class Impl[T] extends Channel.Impl[T] with SyncChannel[T]:
     override def pollRead(r: Reader): Boolean = synchronized:
       // match reader with buffer of senders
       checkClosed(canRead, r) || cells.matchReader(r)
@@ -103,8 +103,8 @@ object SyncChannel:
 end SyncChannel
 
 object BufferedChannel:
-  def apply[T](size: Int = 10)(using SuspendSupport): BufferedChannel[T] = Impl(size)
-  private class Impl[T](size: Int)(using SuspendSupport) extends Channel.Impl[T] with BufferedChannel[T]:
+  def apply[T](size: Int = 10): BufferedChannel[T] = Impl(size)
+  private class Impl[T](size: Int) extends Channel.Impl[T] with BufferedChannel[T]:
     require(size > 0, "Buffered channels must have a buffer size greater than 0")
     val buf = new mutable.Queue[T](size)
 
@@ -275,7 +275,7 @@ object ChannelMultiplexer:
     private var isClosed = false
     private val publishers = ArrayBuffer[ReadableChannel[T]]()
     private val subscribers = ArrayBuffer[SendableChannel[Try[T]]]()
-    private val infoChannel: BufferedChannel[Message] = BufferedChannel[Message](1)(using ac.support)
+    private val infoChannel: BufferedChannel[Message] = BufferedChannel[Message](1)
     ac.scheduler.execute { () =>
       var shouldTerminate = false
       var publishersCopy: List[ReadableChannel[T]] = null

--- a/shared/src/main/scala/async/futures.scala
+++ b/shared/src/main/scala/async/futures.scala
@@ -13,6 +13,7 @@ import java.util.concurrent.CancellationException
 import scala.annotation.tailrec
 import scala.util
 import java.util.concurrent.atomic.AtomicLong
+import scala.util.control.NonFatal
 
 /** A cancellable future that can suspend waiting for other asynchronous sources
   */
@@ -294,7 +295,7 @@ object Future:
   /** Like [[Collector]], but exposes the ability to add futures after creation. */
   class MutableCollector[T](futures: Future[T]*) extends Collector[T](futures*):
     /** Add a new [[Future]] into the collector. */
-    def add(future: Future[T]) = addFuture(future)
+    inline def add(future: Future[T]) = addFuture(future)
     inline def +=(future: Future[T]) = add(future)
 
   extension [T](fs: Seq[Future[T]])
@@ -311,7 +312,7 @@ object Future:
         for _ <- fs do collector.results.read().right.get.value
         fs.map(_.value)
       catch
-        case e: Exception =>
+        case NonFatal(e) =>
           fs.foreach(_.cancel())
           throw e
 

--- a/shared/src/main/scala/async/futures.scala
+++ b/shared/src/main/scala/async/futures.scala
@@ -274,11 +274,6 @@ object Future:
 
   end Promise
 
-  /** Like [[Collector]], but exposes the ability to add futures after creation. */
-  class MutableCollector[T](futures: Future[T]*) extends Collector[T](futures*):
-    /** Add a new [[Future]] into the collector. */
-    def add(future: Future[T]) = addFuture(future)
-    inline def +=(future: Future[T]) = add(future)
   /** Collects a list of futures into a channel of futures, arriving as they finish. */
   class Collector[T](futures: Future[T]*):
     private val ch = UnboundedChannel[Future[T]]()
@@ -292,6 +287,12 @@ object Future:
     futures.foreach(addFuture)
     protected final def addFuture(future: Future[T]) = future.onComplete(listener)
   end Collector
+
+  /** Like [[Collector]], but exposes the ability to add futures after creation. */
+  class MutableCollector[T](futures: Future[T]*) extends Collector[T](futures*):
+    /** Add a new [[Future]] into the collector. */
+    def add(future: Future[T]) = addFuture(future)
+    inline def +=(future: Future[T]) = add(future)
 end Future
 
 /** TaskSchedule describes the way in which a task should be repeated. Tasks can be set to run for example every 100

--- a/shared/src/test/scala/ChannelBehavior.scala
+++ b/shared/src/test/scala/ChannelBehavior.scala
@@ -257,7 +257,7 @@ class ChannelBehavior extends munit.FunSuite {
       }
       val race = Async.race(
         (0 until 100).map(i =>
-          Async.race((10 * i until 10 * i + 10).map(idx => channels(idx).canRead.map(_.mustRead))*)
+          Async.race((10 * i until 10 * i + 10).map(idx => channels(idx).readSource.map(_.mustRead))*)
         )*
       )
       var sum = 0
@@ -284,7 +284,7 @@ class ChannelBehavior extends munit.FunSuite {
       val ch = SyncChannel[Int]()
       var timesSent = 0
       val race = Async.race(
-        (for i <- 0 until 1000 yield ch.canSend(i))*
+        (for i <- 0 until 1000 yield ch.sendSource(i))*
       )
       Future {
         while Async.await(race) != ch.Closed do {
@@ -307,7 +307,7 @@ class ChannelBehavior extends munit.FunSuite {
       Future { assertEquals(b.read().get, 10) }
       var valuesSent = 0
       for i <- 1 to 2 do
-        Async.race(a.canRead, b.canSend(10)).await match
+        Async.race(a.readSource, b.sendSource(10)).await match
           case a.Read(v) => assertEquals(v, 0)
           case b.Sent =>
             valuesSent += 1
@@ -316,7 +316,7 @@ class ChannelBehavior extends munit.FunSuite {
 
       a.close()
       b.close()
-      Async.race(a.canRead, b.canRead).await match
+      Async.race(a.readSource, b.readSource).await match
         case a.Closed | b.Closed => ()
         case r                   => assert(false, s"Should not happen, got $r")
   }

--- a/shared/src/test/scala/ChannelBehavior.scala
+++ b/shared/src/test/scala/ChannelBehavior.scala
@@ -344,7 +344,7 @@ class ChannelBehavior extends munit.FunSuite {
 
       start.await()
 
-      Future { m.start() }
+      Future { m.run() }
       Future {
         for i <- 1 to 4 do c.send(i)
       }
@@ -399,7 +399,7 @@ class ChannelBehavior extends munit.FunSuite {
           l += cr.read().right.get.get
         }
 
-      Future { m.start() }
+      Future { m.run() }
 
       f21.result
       f22.result

--- a/shared/src/test/scala/ChannelBehavior.scala
+++ b/shared/src/test/scala/ChannelBehavior.scala
@@ -356,10 +356,12 @@ class ChannelBehavior extends munit.FunSuite {
   test("ChannelMultiplexer multiple readers and writers") {
     Async.blocking:
       val m = ChannelMultiplexer[Int]()
+      val start = java.util.concurrent.CountDownLatch(5)
 
       val f11 = Future:
         val cc = SyncChannel[Int]()
         m.addPublisher(cc)
+        start.countDown()
         sleep(200)
         for (i <- 0 to 3)
           cc.send(i)
@@ -368,6 +370,7 @@ class ChannelBehavior extends munit.FunSuite {
       val f12 = Future:
         val cc = SyncChannel[Int]()
         m.addPublisher(cc)
+        start.countDown()
         sleep(200)
         for (i <- 10 to 13)
           cc.send(i)
@@ -376,6 +379,7 @@ class ChannelBehavior extends munit.FunSuite {
       val f13 = Future:
         val cc = SyncChannel[Int]()
         m.addPublisher(cc)
+        start.countDown()
         for (i <- 20 to 23)
           cc.send(i)
         m.removePublisher(cc)
@@ -383,6 +387,7 @@ class ChannelBehavior extends munit.FunSuite {
       val f21 = Future:
         val cr = SyncChannel[Try[Int]]()
         m.addSubscriber(cr)
+        start.countDown()
         sleep(200)
         val l = ArrayBuffer[Int]()
         sleep(1000)
@@ -393,12 +398,14 @@ class ChannelBehavior extends munit.FunSuite {
       val f22 = Future:
         val cr = SyncChannel[Try[Int]]()
         m.addSubscriber(cr)
+        start.countDown()
         sleep(1500)
         val l = ArrayBuffer[Int]()
         for (i <- 1 to 12) {
           l += cr.read().right.get.get
         }
 
+      start.await()
       Future { m.run() }
 
       f21.result

--- a/shared/src/test/scala/ChannelBehavior.scala
+++ b/shared/src/test/scala/ChannelBehavior.scala
@@ -22,7 +22,7 @@ import scala.util.Random
 import scala.collection.mutable.{ArrayBuffer, Set}
 import java.util.concurrent.atomic.AtomicInteger
 
-abstract class ChannelBehavior extends munit.FunSuite {
+class ChannelBehavior extends munit.FunSuite {
 
   given ExecutionContext = ExecutionContext.global
 
@@ -164,7 +164,7 @@ abstract class ChannelBehavior extends munit.FunSuite {
   test("reading a closed channel returns Failure(ChannelClosedException)") {
     Async.blocking:
       val c1 = SyncChannel[Int]()
-      val c2 = SyncChannel[Int]()
+      val c2 = BufferedChannel[Int]()
       c1.close()
       c2.close()
       c1.read() match {
@@ -180,7 +180,7 @@ abstract class ChannelBehavior extends munit.FunSuite {
   test("writing to a closed channel throws ChannelClosedException") {
     Async.blocking:
       val c1 = SyncChannel[Int]()
-      val c2 = SyncChannel[Int]()
+      val c2 = BufferedChannel[Int]()
       c1.close()
       c2.close()
       var thrown1 = false
@@ -203,18 +203,18 @@ abstract class ChannelBehavior extends munit.FunSuite {
     val c1 = SyncChannel[Int]()
     val c2 = BufferedChannel[Int](1024)
     for (c <- List(c1, c2)) {
-      var sum = 0
+      var sum = 0L
       Async.blocking:
         val f1 = Future:
-          for (i <- 1 to 10000)
+          for (i <- 1 to 100000)
             c.send(i)
 
         val f2 = Future:
-          for (i <- 1 to 10000)
+          for (i <- 1 to 100000)
             sum += c.read().get
 
         f2.result
-        assertEquals(sum, 50005000)
+        assertEquals(sum, 5000050000L)
     }
   }
 

--- a/shared/src/test/scala/FutureBehavior.scala
+++ b/shared/src/test/scala/FutureBehavior.scala
@@ -410,8 +410,7 @@ class FutureBehavior extends munit.FunSuite {
       val collector = Future.Collector(futs*)
 
       var sum = 0
-      for i <- range do
-        sum += collector.results.read().get.value
+      for i <- range do sum += collector.results.read().right.get.value
       assertEquals(sum, range.sum)
   }
 
@@ -427,12 +426,9 @@ class FutureBehavior extends munit.FunSuite {
           sleep(i * 200)
           collector += r
 
-
       var sum = 0
-      for i <- range do
-        sum += collector.results.read().get.value
-      for i <- range do
-        sum += collector.results.read().get.value
+      for i <- range do sum += collector.results.read().right.get.value
+      for i <- range do sum += collector.results.read().right.get.value
       assertEquals(sum, 2 * range.sum)
   }
 

--- a/shared/src/test/scala/SourceBehavior.scala
+++ b/shared/src/test/scala/SourceBehavior.scala
@@ -163,4 +163,24 @@ class SourceBehavior extends munit.FunSuite {
       sleep(350)
       assertEquals(touched, true)
   }
+
+  test("source values") {
+    Async.blocking:
+      val src = Async.Source.values(1, 2)
+      assertEquals(src.await, 1)
+      assertEquals(src.await, 2)
+
+    Async.blocking:
+      val src = Async.Source.values(1)
+      assertEquals(src.await, 1)
+      assertEquals(
+        Async
+          .race(
+            src, // this should block forever, so never resolve!
+            Future { sleep(200); 0 }
+          )
+          .await,
+        Success(0)
+      )
+  }
 }

--- a/shared/src/test/scala/Timer.scala
+++ b/shared/src/test/scala/Timer.scala
@@ -19,7 +19,7 @@ class TimerTest extends munit.FunSuite {
   test("TimerSleep1Second") {
     Async.blocking:
       val timer = Timer(1.second)
-      Future { timer.start() }
+      Future { timer.run() }
       assert(Async.await(timer.src) == timer.TimerEvent.Tick)
   }
 


### PR DESCRIPTION
Depends on #21 and #22. 

## Channel stuff

- **New implementation for sync and bounded channels**, based on `lockBoth`.
- Remove suspendSupport requirement from channel.
- **New channel kind**: unbounded channels, with `.sendImmediately` non-suspending.
- ChannelMultiplexer changes a bit: there is now a blocking/suspending `start()` method instead of spawning a background working.

## Stuff based on channels

- **Future Collectors**: `Seq[Future[T]]` => `ReadableChannel[Future[T]]`, with values arriving as they are completed.
- Implement collector-based future collection extensions: `Seq[Future[T]]` has `awaitAll`(`OrCancel`) and `altAll`(`WithCancel`)

## Other misc goodies

- Add shorthand `.await` syntax to sources.
- Add `Source.values` to quickly create a new source based on a list of values.
