### PR TITLE
Renaming `result`/`value` to general `awaitResult`/`await`, along other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,14 +187,14 @@ which takes two futures and if they both complete successfully returns their res
   extension [T](f1: Future[T])
 
     def zip[U](f2: Future[U])(using Async): Future[(T, U)] = Future:
-      Async.await(Async.either(f1, f2)) match
+      Async.either(f1, f2).awaitResult match
         case Left(Success(x1))    => (x1, f2.value)
         case Right(Success(x2))   => (f1.value, x2)
         case Left(Failure(ex))    => throw ex
         case Right(Failure(ex))   => throw ex
 
     def alt(f2: Future[T])(using Async): Future[T] = Future:
-      Async.await(Async.either(f1, f2)) match
+      Async.either(f1, f2).awaitResult match
         case Left(Success(x1))    => x1
         case Right(Success(x2))   => x2
         case Left(_: Failure[?])  => f2.value

--- a/jvm/src/main/scala/PosixLikeIO/examples/clientAndServerUDP.scala
+++ b/jvm/src/main/scala/PosixLikeIO/examples/clientAndServerUDP.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext
   Async.blocking:
     val server = Future:
       PIOHelper.withSocketUDP(8134): serverSocket =>
-        val got: DatagramPacket = serverSocket.receive().result.get
+        val got: DatagramPacket = serverSocket.receive().awaitResult.get
         val messageReceived = String(got.getData.slice(0, got.getLength), "UTF-8")
         val responseMessage = (messageReceived.toInt + 1).toString.getBytes
         serverSocket.send(ByteBuffer.wrap(responseMessage), got.getAddress.toString.substring(1), got.getPort)
@@ -25,10 +25,10 @@ import scala.concurrent.ExecutionContext
       Future:
         PIOHelper.withSocketUDP(): clientSocket =>
           val data: Array[Byte] = value.toString.getBytes
-          clientSocket.send(ByteBuffer.wrap(data), "localhost", 8134).result.get
-          val responseDatagram = clientSocket.receive().result.get
+          clientSocket.send(ByteBuffer.wrap(data), "localhost", 8134).awaitResult.get
+          val responseDatagram = clientSocket.receive().awaitResult.get
           val messageReceived = String(responseDatagram.getData.slice(0, responseDatagram.getLength), "UTF-8").toInt
           println("Sent " + value.toString + " and got " + messageReceived.toString + " in return.")
 
-    Async.await(client(100))
-    Async.await(server)
+    client(100).await
+    server.await

--- a/jvm/src/main/scala/PosixLikeIO/examples/readAndWriteFile.scala
+++ b/jvm/src/main/scala/PosixLikeIO/examples/readAndWriteFile.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext
   given ExecutionContext = ExecutionContext.global
   Async.blocking:
     PIOHelper.withFile("/home/julian/Desktop/x.txt", StandardOpenOption.READ, StandardOpenOption.WRITE): f =>
-      Async.await(f.writeString("Hello world! (1)"))
-      println(Async.await(f.readString(1024)).get)
-      Async.await(f.writeString("Hello world! (2)"))
-      println(Async.await(f.readString(1024)).get)
+      f.writeString("Hello world! (1)").await
+      println(f.readString(1024).await)
+      f.writeString("Hello world! (2)").await
+      println(f.readString(1024).await)

--- a/jvm/src/main/scala/PosixLikeIO/examples/readWholeFile.scala
+++ b/jvm/src/main/scala/PosixLikeIO/examples/readWholeFile.scala
@@ -14,11 +14,11 @@ import scala.concurrent.ExecutionContext
   Async.blocking:
     PIOHelper.withFile("/home/julian/Desktop/x.txt", StandardOpenOption.READ): f =>
       val b = ByteBuffer.allocate(1024)
-      val retCode = f.read(b).result.get
+      val retCode = f.read(b).awaitResult.get
       assert(retCode >= 0)
       val s = StandardCharsets.UTF_8.decode(b.slice(0, retCode)).toString()
       println("Read size with read(): " + retCode.toString())
       println("Data: " + s)
 
       println("Read with readString():")
-      println(Async.await(f.readString(1000)).get)
+      println(f.readString(1000).awaitResult)

--- a/jvm/src/main/scala/measurements/measureTimes.scala
+++ b/jvm/src/main/scala/measurements/measureTimes.scala
@@ -46,7 +46,7 @@ def measureIterations[T](action: () => T): Int =
     Async.blocking:
       val f = Future:
         var z = 1
-      f.result
+      f.awaitResult
 
   println("Thread joins per second: " + (threadJoins / 60))
   println("Future joins per second: " + (futureJoins / 60))
@@ -64,26 +64,26 @@ def measureIterations[T](action: () => T): Int =
 
   val c1: Double = measureIterations: () =>
     Async.blocking:
-      Async.await(Async.race(Future { Thread.sleep(10) }, Future { Thread.sleep(100) }, Future { Thread.sleep(50) }))
-      Async.await(Async.race(Future { Thread.sleep(50) }, Future { Thread.sleep(10) }, Future { Thread.sleep(100) }))
-      Async.await(Async.race(Future { Thread.sleep(100) }, Future { Thread.sleep(50) }, Future { Thread.sleep(10) }))
+      Async.race(Future { Thread.sleep(10) }, Future { Thread.sleep(100) }, Future { Thread.sleep(50) }).await
+      Async.race(Future { Thread.sleep(50) }, Future { Thread.sleep(10) }, Future { Thread.sleep(100) }).await
+      Async.race(Future { Thread.sleep(100) }, Future { Thread.sleep(50) }, Future { Thread.sleep(10) }).await
 
   val c2: Double = measureIterations: () =>
     Async.blocking:
       val f11 = Future { Thread.sleep(10) }
       val f12 = Future { Thread.sleep(50) }
       val f13 = Future { Thread.sleep(100) }
-      f11.result
+      f11.awaitResult
 
       val f21 = Future { Thread.sleep(100) }
       val f22 = Future { Thread.sleep(10) }
       val f23 = Future { Thread.sleep(50) }
-      f22.result
+      f22.awaitResult
 
       val f31 = Future { Thread.sleep(50) }
       val f32 = Future { Thread.sleep(100) }
       val f33 = Future { Thread.sleep(10) }
-      f33.result
+      f33.awaitResult
 
   val c1_seconds_wasted_for_waits = c1 * 0.01
   val c1_per_second_adjusted = c1 / 3 / (60 - c1_seconds_wasted_for_waits)
@@ -105,9 +105,9 @@ def measureIterations[T](action: () => T): Int =
 
   val c1: Double = measureIterations: () =>
     Async.blocking:
-      Async.await(Async.race(Future { Thread.sleep(10) }, Future { Thread.sleep(100) }, Future { Thread.sleep(50) }))
-      Async.await(Async.race(Future { Thread.sleep(50) }, Future { Thread.sleep(10) }, Future { Thread.sleep(100) }))
-      Async.await(Async.race(Future { Thread.sleep(100) }, Future { Thread.sleep(50) }, Future { Thread.sleep(10) }))
+      Async.race(Future { Thread.sleep(10) }, Future { Thread.sleep(100) }, Future { Thread.sleep(50) }).await
+      Async.race(Future { Thread.sleep(50) }, Future { Thread.sleep(10) }, Future { Thread.sleep(100) }).await
+      Async.race(Future { Thread.sleep(100) }, Future { Thread.sleep(50) }, Future { Thread.sleep(10) }).await
 
   val c2: Double = measureIterations: () =>
     @volatile var i1 = true
@@ -433,7 +433,7 @@ def measureRunTimes[T](action: () => T): TimeMeasurementResult =
         dataAlmostJson.append(measure("PosixLikeIO", timesInner = if size < 100 then 100 else 10): () =>
           Async.blocking:
             PIOHelper.withFile("/tmp/FIO/x.txt", StandardOpenOption.CREATE, StandardOpenOption.WRITE): f =>
-              f.writeString(bigString.substring(0, size)).result
+              f.writeString(bigString.substring(0, size)).awaitResult
         )
         println("done 1")
 
@@ -466,7 +466,7 @@ def measureRunTimes[T](action: () => T): TimeMeasurementResult =
         dataAlmostJson.append(measure("PosixLikeIO", timesInner = if size < 100 then 100 else 10): () =>
           Async.blocking:
             PIOHelper.withFile("/tmp/FIO/x.txt", StandardOpenOption.READ): f =>
-              f.readString(size).result
+              f.readString(size).awaitResult
         )
         println("done 1")
 

--- a/jvm/src/test/scala/CancellationBehavior.scala
+++ b/jvm/src/test/scala/CancellationBehavior.scala
@@ -17,4 +17,4 @@ class JVMCancellationBehavior extends munit.FunSuite:
       val f = Future:
         Thread.sleep(5000)
         1
-      f.result
+      f.awaitResult

--- a/native/src/main/scala/async/ForkJoinSupport.scala
+++ b/native/src/main/scala/async/ForkJoinSupport.scala
@@ -88,7 +88,7 @@ class SuspendExecutorWithSleep(exec: ExecutionContext)
         val cancellable = schedule(millis.millis, () => resolver.resolve(()))
         resolver.onCancel(cancellable.cancel)
       .link()
-      .value
+      .await
 }
 
 class ForkJoinSupport extends SuspendExecutorWithSleep(new ForkJoinPool())

--- a/shared/src/main/scala/async/Async.scala
+++ b/shared/src/main/scala/async/Async.scala
@@ -58,14 +58,7 @@ object Async:
   inline def current(using async: Async): Async = async
 
   def group[T](body: Async ?=> T)(using async: Async): T =
-    withNewCompletionGroup(CompletionGroup(async.group.handleCompletion).link())(body)
-
-  def withCompletionHandler[T](handler: Cancellable => Async ?=> Unit)(body: Async ?=> T)(using async: Async): T =
-    val combined = (c: Cancellable) =>
-      (async: Async) ?=>
-        handler(c)
-        async.group.handleCompletion(c)
-    withNewCompletionGroup(CompletionGroup(combined).link())(body)
+    withNewCompletionGroup(CompletionGroup().link())(body)
 
   /** Runs a body within another completion group. When the body returns, the group is cancelled and its completion
     * awaited with the `Unlinked` group.

--- a/shared/src/main/scala/async/Cancellable.scala
+++ b/shared/src/main/scala/async/Cancellable.scala
@@ -25,12 +25,6 @@ trait Cancellable:
   def unlink(): this.type =
     link(CompletionGroup.Unlinked)
 
-  /** Signal completion of this cancellable to its group. */
-  def signalCompletion()(using Async): this.type =
-    this.group.handleCompletion(this)
-    this.unlink()
-    this
-
 end Cancellable
 
 object Cancellable:

--- a/shared/src/main/scala/async/CompletionGroup.scala
+++ b/shared/src/main/scala/async/CompletionGroup.scala
@@ -25,7 +25,7 @@ class CompletionGroup(val handleCompletion: Cancellable => Async ?=> Unit = _ =>
   private[async] def waitCompletion()(using Async): Unit =
     synchronized:
       if members.nonEmpty && cancelWait.isEmpty then cancelWait = Some(Promise())
-    cancelWait.foreach(cWait => Async.await(cWait.future))
+    cancelWait.foreach(cWait => cWait.future.await)
     signalCompletion()
 
   /** Add given member to the members set. If the group has already been cancelled, cancels that member immediately. */

--- a/shared/src/main/scala/async/CompletionGroup.scala
+++ b/shared/src/main/scala/async/CompletionGroup.scala
@@ -5,10 +5,8 @@ import scala.util.Success
 
 /** A group of cancellable objects that are completed together. Cancelling the group means cancelling all its
   * uncompleted members.
-  * @param handleCompletion
-  *   a function that gets applied to every member when it is completed or cancelled
   */
-class CompletionGroup(val handleCompletion: Cancellable => Async ?=> Unit = _ => {}) extends Cancellable.Tracking:
+class CompletionGroup extends Cancellable.Tracking:
   private val members: mutable.Set[Cancellable] = mutable.Set()
   private var canceled: Boolean = false
   private var cancelWait: Option[Promise[Unit]] = None
@@ -26,7 +24,7 @@ class CompletionGroup(val handleCompletion: Cancellable => Async ?=> Unit = _ =>
     synchronized:
       if members.nonEmpty && cancelWait.isEmpty then cancelWait = Some(Promise())
     cancelWait.foreach(cWait => cWait.future.await)
-    signalCompletion()
+    unlink()
 
   /** Add given member to the members set. If the group has already been cancelled, cancels that member immediately. */
   def add(member: Cancellable): Unit =

--- a/shared/src/main/scala/async/channels.scala
+++ b/shared/src/main/scala/async/channels.scala
@@ -3,7 +3,6 @@ import scala.collection.mutable
 import mutable.{ArrayBuffer, ListBuffer}
 
 import scala.util.{Failure, Success, Try}
-import Async.await
 
 import scala.util.control.Breaks.{break, breakable}
 import gears.async.Async.Source
@@ -26,7 +25,7 @@ trait SendableChannel[-T]:
   /** Send [[x]] over the channel, blocking (asynchronously with [[Async]]) until the item has been sent or, if the
     * channel is buffered, queued. Throws [[ChannelClosedException]] if the channel was closed.
     */
-  def send(x: T)(using Async): Unit = Async.await(sendSource(x)) match
+  def send(x: T)(using Async): Unit = sendSource(x).awaitResult match
     case Right(_) => ()
     case Left(_)  => throw ChannelClosedException()
 end SendableChannel
@@ -45,7 +44,7 @@ trait ReadableChannel[+T]:
   /** Read an item from the channel, blocking (asynchronously with [[Async]]) until the item has been received. Returns
     * `Failure(ChannelClosedException)` if the channel was closed.
     */
-  def read()(using Async): Res[T] = await(readSource)
+  def read()(using Async): Res[T] = readSource.awaitResult
 end ReadableChannel
 
 /** A generic channel that can be sent to, received from and closed. */

--- a/shared/src/main/scala/async/futures.scala
+++ b/shared/src/main/scala/async/futures.scala
@@ -7,7 +7,6 @@ import scala.collection.mutable
 import mutable.ListBuffer
 
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.CancellationException
 import scala.compiletime.uninitialized
 import scala.util.{Failure, Success, Try}
@@ -61,7 +60,7 @@ object Future:
         else this
 
     /** Sets the cancellation state and returns `true` if the future has not been completed and cancelled before. */
-    protected def setCancelled(): Boolean =
+    protected final def setCancelled(): Boolean =
       !hasCompleted && cancelRequest.compareAndSet(false, true)
 
     /** Complete future with result. If future was cancelled in the meantime, return a CancellationException failure

--- a/shared/src/main/scala/async/futures.scala
+++ b/shared/src/main/scala/async/futures.scala
@@ -43,8 +43,7 @@ object Future:
       else false
 
     def addListener(k: Listener[Try[T]]): Unit = synchronized:
-      if hasCompleted then k.completeNow(result, this)
-      else waiting += k
+      waiting += k
 
     def dropListener(k: Listener[Try[T]]): Unit = synchronized:
       waiting -= k

--- a/shared/src/main/scala/async/futures.scala
+++ b/shared/src/main/scala/async/futures.scala
@@ -186,7 +186,7 @@ object Future:
         if setCancelled() then
           cancelHandle()
           reject(CancellationException())
-          this.unlink()
+        this.unlink()
     }
     body(future)
     future

--- a/shared/src/test/scala/CancellationBehavior.scala
+++ b/shared/src/test/scala/CancellationBehavior.scala
@@ -77,7 +77,7 @@ class CancellationBehavior extends munit.FunSuite:
       val promise = Future.Promise[Unit]()
       Async.group:
         startFuture(info, promise.complete(Success(())))
-        Async.await(promise.future)
+        promise.future.await
       info.assertCancelled()
 
   test("nested link group"):
@@ -89,13 +89,13 @@ class CancellationBehavior extends munit.FunSuite:
           info1, {
             Async.group:
               startFuture(info2, promise2.complete(Success(())))
-              Async.await(promise2.future)
+              promise2.future.await
             info2.assertCancelled()
-            Future.now(Success(())).value // check cancellation
+            Future.now(Success(())).await // check cancellation
             promise1.complete(Success(()))
           }
         )
-        Async.await(promise1.future)
+        promise1.future.await
       info1.assertCancelled()
       info2.assertCancelled()
 
@@ -123,6 +123,6 @@ class CancellationBehavior extends munit.FunSuite:
       Async.group:
         Async.current.group.cancel() // cancel now
         val f = startFuture(info, promise.complete(Success(())))
-        Async.await(promise.future)
-        Async.await(f)
+        promise.future.awaitResult
+        f.awaitResult
         info.assertCancelled()

--- a/shared/src/test/scala/ChannelBehavior.scala
+++ b/shared/src/test/scala/ChannelBehavior.scala
@@ -42,8 +42,8 @@ class ChannelBehavior extends munit.FunSuite {
       val f2 = Future:
         c.read()
 
-      f1.result
-      f2.result
+      f1.awaitResult
+      f2.awaitResult
   }
 
   test("sending is nonblocking in empty BufferedChannel") {
@@ -59,8 +59,8 @@ class ChannelBehavior extends munit.FunSuite {
       val f2 = Future:
         c.read()
 
-      f1.result
-      f2.result
+      f1.awaitResult
+      f2.awaitResult
   }
 
   test("sending is blocking in full BufferedChannel") {
@@ -80,8 +80,8 @@ class ChannelBehavior extends munit.FunSuite {
       val f2 = Future:
         c.read()
 
-      f1.result
-      f2.result
+      f1.awaitResult
+      f2.awaitResult
   }
 
   test("read blocks until value is available in SyncChannel") {
@@ -100,9 +100,9 @@ class ChannelBehavior extends munit.FunSuite {
         c.read()
         assertEquals(touched, true)
 
-      f1.result
-      f11.result
-      f2.result
+      f1.awaitResult
+      f11.awaitResult
+      f2.awaitResult
   }
 
   test("read blocks until value is available in BufferedChannel") {
@@ -121,9 +121,9 @@ class ChannelBehavior extends munit.FunSuite {
         c.read()
         assertEquals(touched, true)
 
-      f1.result
-      f11.result
-      f2.result
+      f1.awaitResult
+      f11.awaitResult
+      f2.awaitResult
   }
 
   test("values arrive in order") {
@@ -199,7 +199,7 @@ class ChannelBehavior extends munit.FunSuite {
           for (i <- 1 to 10000)
             sum += c.read().right.get
 
-        f2.result
+        f2.awaitResult
         assertEquals(sum, 50005000L)
     }
   }
@@ -236,15 +236,15 @@ class ChannelBehavior extends munit.FunSuite {
             gotCount.incrementAndGet()
           }
 
-        f21.result
-        f22.result
+        f21.awaitResult
+        f22.awaitResult
         while (gotCount.get() < 30000) {
           c.read()
           gotCount.incrementAndGet()
         }
-        f11.result
-        f12.result
-        f13.result
+        f11.awaitResult
+        f12.awaitResult
+        f13.awaitResult
     }
   }
 
@@ -260,7 +260,7 @@ class ChannelBehavior extends munit.FunSuite {
         )*
       )
       var sum = 0
-      for i <- 0 until 1000 do sum += Async.await(race)
+      for i <- 0 until 1000 do sum += race.awaitResult
       assertEquals(sum, (0 until 1000).sum)
   }
 
@@ -286,7 +286,7 @@ class ChannelBehavior extends munit.FunSuite {
         (for i <- 0 until 1000 yield ch.sendSource(i))*
       )
       Future {
-        while Async.await(race).isRight do {
+        while race.awaitResult.isRight do {
           timesSent += 1
         }
       }
@@ -318,7 +318,7 @@ class ChannelBehavior extends munit.FunSuite {
 
       a.close()
       b.close()
-      assert(Async.race(a.readSource, b.readSource).await.isLeft)
+      assert(Async.race(a.readSource, b.readSource).awaitResult.isLeft)
   }
 
   test("ChannelMultiplexer multiplexes - all subscribers read the same stream") {

--- a/shared/src/test/scala/ChannelBehavior.scala
+++ b/shared/src/test/scala/ChannelBehavior.scala
@@ -7,9 +7,7 @@ import gears.async.{
   SyncChannel,
   Task,
   TaskSchedule,
-  UnboundedChannel,
-  alt,
-  altC
+  UnboundedChannel
 }
 import gears.async.default.given
 import gears.async.AsyncOperations.*

--- a/shared/src/test/scala/FutureBehavior.scala
+++ b/shared/src/test/scala/FutureBehavior.scala
@@ -27,11 +27,11 @@ class FutureBehavior extends munit.FunSuite {
         }
         val res = c
           .alt(Future {
-            val res = a.value + b.value
+            val res = a.await + b.await
             res
           })
           .alt(c)
-          .value
+          .await
         res
       val y = Future:
         val a = Future {
@@ -40,7 +40,7 @@ class FutureBehavior extends munit.FunSuite {
         val b = Future {
           11
         }
-        val res = a.zip(b).value
+        val res = a.zip(b).await
         res
       val z = Future:
         val a = Future {
@@ -49,11 +49,11 @@ class FutureBehavior extends munit.FunSuite {
         val b = Future {
           true
         }
-        val res = a.alt(b).value
+        val res = a.alt(b).await
         res
       val _: Future[Int | Boolean] = z
-      assertEquals(x.value, 33)
-      assertEquals(y.value, (22, 11))
+      assertEquals(x.await, 33)
+      assertEquals(y.await, (22, 11))
   }
 
   test("Constant returns") {
@@ -61,14 +61,14 @@ class FutureBehavior extends munit.FunSuite {
       for (i <- -5 to 5)
         val f1 = Future { i }
         val f2 = Future.now(Success(i))
-        assertEquals(f1.value, i)
-        assertEquals(f1.value, f2.value)
+        assertEquals(f1.await, i)
+        assertEquals(f1.await, f2.await)
   }
 
   test("Future.now returning") {
     Async.blocking:
       val f = Future.now(Success(116))
-      assertEquals(f.value, 116)
+      assertEquals(f.await, 116)
   }
 
   test("Constant future with timeout") {
@@ -77,7 +77,7 @@ class FutureBehavior extends munit.FunSuite {
         sleep(50)
         55
       }
-      assertEquals(f.value, 55)
+      assertEquals(f.await, 55)
   }
 
   test("alt") {
@@ -87,10 +87,10 @@ class FutureBehavior extends munit.FunSuite {
       val fail1 = Future.now(Failure(error))
       val succeed = Future.now(Success(13))
 
-      assert(Set(10, 20).contains(Future { 10 }.alt(Future { 20 }).value))
-      assertEquals(fail.alt(succeed).value, 13)
-      assertEquals(succeed.alt(fail).value, 13)
-      assertEquals(fail.alt(fail1).result, Failure(error))
+      assert(Set(10, 20).contains(Future { 10 }.alt(Future { 20 }).await))
+      assertEquals(fail.alt(succeed).await, 13)
+      assertEquals(succeed.alt(fail).await, 13)
+      assertEquals(fail.alt(fail1).awaitResult, Failure(error))
   }
 
   test("altC of 2 futures") {
@@ -101,7 +101,7 @@ class FutureBehavior extends munit.FunSuite {
         touched += 1
       }.alt(Future {
         10
-      }).result
+      }).awaitResult
       sleep(300)
       assertEquals(touched, 1)
     Async.blocking:
@@ -109,7 +109,7 @@ class FutureBehavior extends munit.FunSuite {
       Future {
         sleep(200)
         touched += 1
-      }.altWithCancel(Future { 10 }).result
+      }.altWithCancel(Future { 10 }).awaitResult
       sleep(300)
       assertEquals(touched, 0)
   }
@@ -129,13 +129,13 @@ class FutureBehavior extends munit.FunSuite {
         Future {
           5
         }
-      ).result
+      ).awaitResult
       sleep(200)
       assertEquals(touched.get(), 2)
     }
     Async.blocking:
       var touched = 0
-      altC(Future { sleep(100); touched += 1 }, Future { sleep(100); touched += 1 }, Future { 5 }).result
+      altC(Future { sleep(100); touched += 1 }, Future { sleep(100); touched += 1 }, Future { 5 }).awaitResult
       sleep(200)
       assertEquals(touched, 0)
   }
@@ -147,23 +147,23 @@ class FutureBehavior extends munit.FunSuite {
       val fail1 = Future.now(Failure(error))
       val succeed = Future.now(Success(13))
 
-      assertEquals(Future { 10 }.zip(Future { 20 }).value, (10, 20))
-      assertEquals(fail.zip(succeed).result, Failure(error))
-      assertEquals(succeed.zip(fail).result, Failure(error))
-      assertEquals(fail.zip(fail1).result, Failure(error))
+      assertEquals(Future { 10 }.zip(Future { 20 }).await, (10, 20))
+      assertEquals(fail.zip(succeed).awaitResult, Failure(error))
+      assertEquals(succeed.zip(fail).awaitResult, Failure(error))
+      assertEquals(fail.zip(fail1).awaitResult, Failure(error))
   }
 
   test("result wraps exceptions") {
     Async.blocking:
       for (i <- -5 to 5)
         val error = new AssertionError(i)
-        assertEquals(Future { throw error }.result, Failure(error))
+        assertEquals(Future { throw error }.awaitResult, Failure(error))
   }
 
   test("result wraps values") {
     Async.blocking:
       for (i <- -5 to 5)
-        assertEquals(Future { i }.result, Success(i))
+        assertEquals(Future { i }.awaitResult, Success(i))
   }
 
   test("value propagates exceptions exceptions through futures") {
@@ -173,9 +173,9 @@ class FutureBehavior extends munit.FunSuite {
         val f1 = Future {
           throw e
         }
-        (f1.value, f1.value)
+        (f1.await, f1.await)
       }
-      try f.value
+      try f.await
       catch
         case e1: AssertionError => assertEquals(e, e1)
         case z =>
@@ -191,9 +191,9 @@ class FutureBehavior extends munit.FunSuite {
           Future {
             sleep(Random.between(0, 15L))
             10
-          }.value
-        }.value
-      }.value
+          }.await
+        }.await
+      }.await
       assertEquals(z, 10)
   }
 
@@ -204,7 +204,7 @@ class FutureBehavior extends munit.FunSuite {
         10
       }
       f.cancel()
-      f.result match
+      f.awaitResult match
         case _: Failure[CancellationException] => ()
         case _                                 => assert(false)
   }
@@ -219,7 +219,7 @@ class FutureBehavior extends munit.FunSuite {
         }.unlink()
         10
       }
-      assertEquals(f.value, 10)
+      assertEquals(f.await, 10)
       assertEquals(zombieModifiedThis, false)
     Thread.sleep(300)
     assertEquals(zombieModifiedThis, true)
@@ -239,7 +239,7 @@ class FutureBehavior extends munit.FunSuite {
             Future {
               30
             }
-          ).value
+          ).await
         )
       )
   }
@@ -249,13 +249,13 @@ class FutureBehavior extends munit.FunSuite {
       val z1 = Future { sleep(500); 10 } *: Future { sleep(10); 222 } *: Future { sleep(150); 333 } *: Future {
         EmptyTuple
       }
-      assertEquals(z1.value, (10, 222, 333))
+      assertEquals(z1.await, (10, 222, 333))
   }
 
   test("zip on tuples with last zip") {
     Async.blocking:
       val z1 = Future { 10 } *: Future { 222 }.zip(Future { 333 })
-      assertEquals(z1.value, (10, 222, 333))
+      assertEquals(z1.await, (10, 222, 333))
   }
 
   test("zip(3) first error") {
@@ -274,7 +274,7 @@ class FutureBehavior extends munit.FunSuite {
           } *: Future {
             sleep(Random.between(50, 100));
             throw e3
-          } *: Future.now(Success(EmptyTuple))).result,
+          } *: Future.now(Success(EmptyTuple))).awaitResult,
           Failure(e3)
         )
   }
@@ -291,7 +291,7 @@ class FutureBehavior extends munit.FunSuite {
       futures.foreach(_.cancel())
       val exceptionSet = mutable.Set[Throwable]()
       for (f <- futures) {
-        f.result match {
+        f.awaitResult match {
           case Failure(e) => exceptionSet.add(e)
           case _          => assert(false)
         }
@@ -307,7 +307,7 @@ class FutureBehavior extends munit.FunSuite {
           j = i
         }
         val f2 = Future.now(Success(i))
-        assertEquals(j, f2.value)
+        assertEquals(j, f2.await)
         assertEquals(j, i)
   }
 
@@ -322,9 +322,9 @@ class FutureBehavior extends munit.FunSuite {
       }
       sleep(50)
       f.cancel()
-      f.result
+      f.awaitResult
       assertEquals(touched, true)
-      f.result match
+      f.awaitResult match
         case Failure(ex) if ex.isInstanceOf[CancellationException] => ()
         case _                                                     => assert(false)
   }
@@ -335,7 +335,7 @@ class FutureBehavior extends munit.FunSuite {
       p.complete(Success(10))
       val f = p.future
       f.cancel()
-      f.result match
+      f.awaitResult match
         case Failure(ex) if ex.isInstanceOf[CancellationException] => ()
         case _                                                     => assert(false)
   }
@@ -353,7 +353,7 @@ class FutureBehavior extends munit.FunSuite {
       }
       sleep(50)
       f1.cancel()
-      f1.result
+      f1.awaitResult
       assertEquals(touched1, true)
       assertEquals(touched2, false)
   }
@@ -372,7 +372,7 @@ class FutureBehavior extends munit.FunSuite {
             Future {
               sleep(Random.between(30, 50)); 10000 * i + 333
             }
-          ).result,
+          ).awaitResult,
           Success(10000 * i + 333)
         )
   }
@@ -398,7 +398,7 @@ class FutureBehavior extends munit.FunSuite {
               sleep(Random.between(0, 250));
               throw e3
             }
-          ).result,
+          ).awaitResult,
           Failure(e2)
         )
   }
@@ -410,7 +410,7 @@ class FutureBehavior extends munit.FunSuite {
       val collector = Future.Collector(futs*)
 
       var sum = 0
-      for i <- range do sum += collector.results.read().right.get.value
+      for i <- range do sum += collector.results.read().right.get.await
       assertEquals(sum, range.sum)
   }
 
@@ -427,8 +427,8 @@ class FutureBehavior extends munit.FunSuite {
           collector += r
 
       var sum = 0
-      for i <- range do sum += collector.results.read().right.get.value
-      for i <- range do sum += collector.results.read().right.get.value
+      for i <- range do sum += collector.results.read().right.get.await
+      for i <- range do sum += collector.results.read().right.get.await
       assertEquals(sum, 2 * range.sum)
   }
 

--- a/shared/src/test/scala/FutureBehavior.scala
+++ b/shared/src/test/scala/FutureBehavior.scala
@@ -189,11 +189,12 @@ class FutureBehavior extends munit.FunSuite {
       var touched = false
       val fut = Future:
         Future:
-          sleep(2000)
+          sleep(1000)
           touched = true
+        sleep(500)
         10
       assertEquals(fut.await, 10)
-      sleep(2000)
+      sleep(1000)
       assertEquals(touched, false)
   }
 

--- a/shared/src/test/scala/FutureBehavior.scala
+++ b/shared/src/test/scala/FutureBehavior.scala
@@ -287,12 +287,21 @@ class FutureBehavior extends munit.FunSuite {
   test("Promise can be cancelled") {
     Async.blocking:
       val p = Promise[Int]()
-      p.complete(Success(10))
       val f = p.future
       f.cancel()
+      p.complete(Success(10))
       f.awaitResult match
         case Failure(ex) if ex.isInstanceOf[CancellationException] => ()
         case _                                                     => assert(false)
+  }
+
+  test("Promise can't be cancelled after completion") {
+    Async.blocking:
+      val p = Promise[Int]()
+      p.complete(Success(10))
+      val f = p.future
+      f.cancel()
+      assertEquals(f.await, 10)
   }
 
   test("Nesting of cancellations") {

--- a/shared/src/test/scala/FutureBehavior.scala
+++ b/shared/src/test/scala/FutureBehavior.scala
@@ -184,6 +184,19 @@ class FutureBehavior extends munit.FunSuite {
         case _                                 => assert(false)
   }
 
+  test("future should cancel its group when the main body is completed") {
+    Async.blocking:
+      var touched = false
+      val fut = Future:
+        Future:
+          sleep(2000)
+          touched = true
+        10
+      assertEquals(fut.await, 10)
+      sleep(2000)
+      assertEquals(touched, false)
+  }
+
   test("zombie threads exist and run to completion after the Async.blocking barrier") {
     var zombieModifiedThis = false
     Async.blocking:

--- a/shared/src/test/scala/TaskScheduleBehavior.scala
+++ b/shared/src/test/scala/TaskScheduleBehavior.scala
@@ -16,7 +16,7 @@ class TaskScheduleBehavior extends munit.FunSuite {
       val f = Task {
         i += 1
       }.schedule(TaskSchedule.Every(100, 3)).run
-      f.result
+      f.awaitResult
       assertEquals(i, 3)
     val end = System.currentTimeMillis()
     assert(end - start >= 200)
@@ -30,7 +30,7 @@ class TaskScheduleBehavior extends munit.FunSuite {
       val f = Task {
         i += 1
       }.schedule(TaskSchedule.ExponentialBackoff(50, 2, 5)).run
-      f.result
+      f.awaitResult
       assertEquals(i, 5)
     val end = System.currentTimeMillis()
     assert(end - start >= 50 + 100 + 200 + 400)
@@ -44,7 +44,7 @@ class TaskScheduleBehavior extends munit.FunSuite {
       val f = Task {
         i += 1
       }.schedule(TaskSchedule.FibonacciBackoff(10, 6)).run
-      f.result
+      f.awaitResult
       assertEquals(i, 6)
     val end = System.currentTimeMillis()
     assert(end - start >= 0 + 10 + 10 + 20 + 30 + 50)
@@ -61,7 +61,7 @@ class TaskScheduleBehavior extends munit.FunSuite {
           Failure(AssertionError())
         } else Success(i)
       }
-      val ret = t.schedule(TaskSchedule.RepeatUntilSuccess(150)).run.result
+      val ret = t.schedule(TaskSchedule.RepeatUntilSuccess(150)).run.awaitResult
       assertEquals(ret.get.get, 4)
     val end = System.currentTimeMillis()
     assert(end - start >= 4 * 150)
@@ -79,7 +79,7 @@ class TaskScheduleBehavior extends munit.FunSuite {
           Success(i)
         } else Failure(ex)
       }
-      val ret = t.schedule(TaskSchedule.RepeatUntilFailure(150)).run.result
+      val ret = t.schedule(TaskSchedule.RepeatUntilFailure(150)).run.awaitResult
       assertEquals(ret.get, Failure(ex))
     val end = System.currentTimeMillis()
     assert(end - start >= 4 * 150)

--- a/shared/src/test/scala/TaskScheduleBehavior.scala
+++ b/shared/src/test/scala/TaskScheduleBehavior.scala
@@ -1,4 +1,4 @@
-import gears.async.{Async, Future, Task, TaskSchedule, alt}
+import gears.async.{Async, Future, Task, TaskSchedule}
 import gears.async.default.given
 import Future.{*:, zip}
 

--- a/shared/src/test/scala/Timer.scala
+++ b/shared/src/test/scala/Timer.scala
@@ -20,13 +20,13 @@ class TimerTest extends munit.FunSuite {
     Async.blocking:
       val timer = Timer(1.second)
       Future { timer.run() }
-      assert(Async.await(timer.src) == timer.TimerEvent.Tick)
+      assert(timer.src.awaitResult == timer.TimerEvent.Tick)
   }
 
   def timeoutCancellableFuture[T](d: Duration, f: Future[T])(using Async, AsyncOperations): Future[T] =
     val t = Future { sleep(d.toMillis) }
     Future:
-      val g = Async.await(Async.either(t, f))
+      val g = Async.either(t, f).awaitResult
       g match
         case Left(_) =>
           f.cancel()
@@ -44,7 +44,7 @@ class TimerTest extends munit.FunSuite {
           sleep(1000)
           touched = true
       )
-      Async.await(t)
+      t.await
       assert(!touched)
       sleep(2000)
       assert(!touched)


### PR DESCRIPTION
- Rename result => awaitResult, value => await, make them Source methods
- use more efficient alt/altCancel using Promises rather than spawning Futures
- Slight improvement of the tests
- Guarantee that future cancellation is done once
