### PR TITLE
replace git url with http for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "dependencies/scala-native"]
 	path = dependencies/scala-native
-	url = git@github.com:scala-native/scala-native.git
+	url = https://github.com/scala-native/scala-native.git
 [submodule "dependencies/munit"]
 	path = dependencies/munit
-	url = git@github.com:natsukagami/munit.git
+	url = https://github.com/natsukagami/munit.git
 	branch = use-0.5-snapshot-sn


### PR DESCRIPTION
Current setup breaks if someone does not have git ssh keys set up.