### PR TITLE
Fix dropping of listeners for transformValuesWith

### DIFF
--- a/shared/src/main/scala/async/Async.scala
+++ b/shared/src/main/scala/async/Async.scala
@@ -161,7 +161,7 @@ object Async:
       new Source[U]:
         selfSrc =>
         def transform(k: Listener[U]) =
-          new Listener[T]:
+          new Listener.ForwardingListener[T](selfSrc, k):
             val lock = withLock(k) { inner => new ListenerLockWrapper(inner, selfSrc) }
             def complete(data: T, source: Async.Source[T]) =
               k.complete(f(data), selfSrc)

--- a/shared/src/test/scala/SourceBehavior.scala
+++ b/shared/src/test/scala/SourceBehavior.scala
@@ -183,4 +183,22 @@ class SourceBehavior extends munit.FunSuite {
         Success(0)
       )
   }
+
+  test("transformValuesWith unsubscribes") {
+    val base = Future.Promise[Unit]()
+    val derived = base.transformValuesWith(_ => ())
+
+    var touched = false
+    val listener = Listener { (_data, _src) => touched = true }
+
+    derived.onComplete(listener)
+    assert(!touched)
+
+    derived.dropListener(listener)
+    base.complete(Success(()))
+    assert(!touched)
+
+    derived.onComplete(listener)
+    assert(touched)
+  }
 }


### PR DESCRIPTION
This seems to have got broken in some iteration. I checked for further `new Listener`... occurrences but this seems to be the only miss.