### PR TITLE
Use interruptGuard in VThreadScheduler

### DIFF
--- a/jvm/src/main/scala/async/VThreadSupport.scala
+++ b/jvm/src/main/scala/async/VThreadSupport.scala
@@ -3,7 +3,6 @@ package gears.async
 import scala.annotation.unchecked.uncheckedVariance
 import java.util.concurrent.locks.ReentrantLock
 import scala.concurrent.duration.FiniteDuration
-import java.util.concurrent.atomic.AtomicBoolean
 import java.lang.invoke.{VarHandle, MethodHandles}
 
 object VThreadScheduler extends Scheduler:

--- a/shared/src/test/scala/SchedulerBehavior.scala
+++ b/shared/src/test/scala/SchedulerBehavior.scala
@@ -1,0 +1,42 @@
+import gears.async.{Async, Future, Listener}
+import gears.async.AsyncOperations.*
+import gears.async.default.given
+import concurrent.duration.DurationInt
+import gears.async.Future.Promise
+import scala.util.Success
+
+class SchedulerBehavior extends munit.FunSuite {
+  test("schedule cancellation works") {
+    Async.blocking:
+      var bodyRan = false
+      val cancellable = Async.current.scheduler.schedule(1.seconds, () => bodyRan = true)
+
+      // cancel immediately
+      cancellable.cancel()
+
+      sleep(1000)
+      assert(!bodyRan)
+  }
+
+  test("schedule cancellation doesn't abort inner code") {
+    Async.blocking:
+      var bodyRan = false
+      val fut = Promise[Unit]()
+      val cancellable = Async.current.scheduler.schedule(
+        50.milliseconds,
+        () =>
+          fut.complete(Success(()))
+          Async.blocking:
+            sleep(500)
+            bodyRan = true
+      )
+
+      // cancel after body started running
+      fut.await
+      cancellable.cancel()
+
+      sleep(1000)
+
+      assert(bodyRan)
+  }
+}


### PR DESCRIPTION
A simple solution to this double scheduling. Allocate `AtomicBoolean` vs a new virtual thread.

Happy New Year! 🎉 