### PR TITLE
Update scala-native, use default GC

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ lazy val root =
       Seq(
         nativeConfig ~= { c =>
           c.withMultithreadingSupport(true)
-            .withGC(GC.boehm)
         },
         libraryDependencies += "org.scalameta" %%% "munit" % "1.0.0-M10+16-4e2ab919-SNAPSHOT" % Test
       )


### PR DESCRIPTION
With the new `BlobArray` implementation and usage in Continuations, we can now safely use the default GC (immix/commix) as well as Boehm.
Remove the Boehm GC requirement from `build.sbt`.
