### PR TITLE
Remove nested listener locks

### DIFF
--- a/shared/src/main/scala/async/Async.scala
+++ b/shared/src/main/scala/async/Async.scala
@@ -202,9 +202,10 @@ object Async:
                 override def acquire() =
                   if found then false // already completed
                   else if !k.lock.acquire() then
-                    if !found && synchronized { // getAndSet alternative, avoid racing only with self here.
-                        if !found then { found = false; true }
-                        else false
+                    if !found && !synchronized { // getAndSet alternative, avoid racing only with self here.
+                        val old = found
+                        found = true
+                        old
                       }
                     then sources.foreach(_.dropListener(self)) // same as dropListener(k), but avoids an allocation
                     false

--- a/shared/src/main/scala/async/Listener.scala
+++ b/shared/src/main/scala/async/Listener.scala
@@ -31,24 +31,23 @@ trait Listener[-T]:
     */
   val lock: Listener.ListenerLock | Null
 
-  /** Attempts to acquire all locks and then calling [[complete]] with the given item and source. If locking fails,
-    * [[releaseAll]] is automatically called.
+  /** Attempts to acquire locks and then calling [[complete]] with the given item and source. If locking fails,
+    * [[release]] is automatically called.
     */
   def completeNow(data: T, source: Async.Source[T]): Boolean =
-    lockCompletely(source) match
-      case Locked =>
-        this.complete(data, source)
-        true
-      case Gone => false
+    if lockCompletely() then
+      this.complete(data, source)
+      true
+    else false
 
   /** Release the listener lock up to the given [[Listener.LockMarker]], if it exists. */
-  inline final def releaseLock(to: Listener.LockMarker): Unit = if lock != null then lock.releaseAll(to)
+  inline final def releaseLock(): Unit = if lock != null then lock.release()
 
-  /** Attempts to completely lock the listener, if such a lock exists. Succeeds with [[Listener.Locked]] immediately if
-    * there is no [[Listener.ListenerLock]]. If locking fails, [[releaseAll]] is automatically called.
+  /** Attempts to completely lock the listener, if such a lock exists. Succeeds with [[true]] immediately if there is no
+    * [[Listener.ListenerLock]]. If locking fails, [[releaseAll]] is automatically called.
     */
-  inline final def lockCompletely(source: Async.Source[T]): Locked.type | Gone.type =
-    if lock != null then lock.lockAll(source) else Locked
+  inline final def lockCompletely(): Boolean =
+    if lock != null then lock.lockSelf() else true
 
 object Listener:
   /** A simple [[Listener]] that always accepts the item and sends it to the consumer. */
@@ -72,29 +71,6 @@ object Listener:
       val lock = null
       override def complete(data: T, source: Async.Source[T]) = ???
 
-  /** The result of locking a single listener lock. */
-  sealed trait LockResult
-
-  /** We have completed locking the listener. It can now be `complete`d. */
-  case object Locked extends LockResult
-
-  /** The listener is no longer available. It should be removed from the source, and any acquired locks by the source
-    * must be manually `release`d by the source itself.
-    */
-  case object Gone extends LockResult
-
-  /** Locking is successful; however, there are more locks to be acquired. */
-  trait PartialLock extends LockResult:
-    /** The number of the next lock. */
-    val nextNumber: Long
-
-    /** Attempt to lock the next lock. */
-    def lockNext(): LockResult
-
-  /** Points to a position on the lock chain, whose lock up until this point has been acquired, but no further.
-    */
-  type LockMarker = PartialLock | Locked.type
-
   /** A lock required by a listener to be acquired before accepting values. Should there be multiple listeners that
     * needs to be locked at the same time, they should be locked by larger-number-first.
     *
@@ -111,46 +87,15 @@ object Listener:
       */
     val selfNumber: Long
 
-    /** Attempt to lock the current [[ListenerLock]]. To try to lock all possible nesting locks, see
-      * [[Listener.lockCompletely]]. Locks are guaranteed to be held as short as possible.
+    /** Attempt to lock the current [[ListenerLock]]. Locks are guaranteed to be held as short as possible.
       */
-    def lockSelf(source: Async.Source[?]): LockResult
+    def lockSelf(): Boolean
 
     /** Release the current lock without resolving the listener with any items, if the current listener lock is before
-      * or the same as the current [[Listener.LockMarker]]. Returns the next lock to be released, `null` if there are no
-      * more.
+      * or the same as the current [[Listener.LockMarker]].
       */
-    protected def release(to: Listener.LockMarker): ListenerLock | Null
-
-    /** Attempt to release all locks up to and including the given [[Listener.LockMarker]]. */
-    @tailrec
-    final def releaseAll(to: Listener.LockMarker): Unit =
-      val rest = release(to)
-      if rest != null then rest.releaseAll(to)
-
-    /** Attempt to lock all layers of this listener lock. */
-    private[Listener] final def lockAll(source: Async.Source[?]): Locked.type | Gone.type =
-      lockSelf(source) match
-        case Locked             => Locked
-        case Gone               => Gone
-        case inner: PartialLock => lockRecursively(inner)
-
-    @tailrec
-    private final def lockRecursively(l: Listener.PartialLock): Locked.type | Gone.type =
-      l.lockNext() match
-        case Locked => Locked
-        case Gone =>
-          this.releaseAll(l)
-          Gone
-        case inner: PartialLock => lockRecursively(inner)
+    def release(): Unit
   end ListenerLock
-
-  /** A special wrapper for [[ListenerLock]] that just passes the source through. */
-  class ListenerLockWrapper(inner: ListenerLock, src: Async.Source[?]) extends ListenerLock:
-    val selfNumber: Long = inner.selfNumber
-    def lockSelf(_src: Async.Source[?]) =
-      inner.lockSelf(src)
-    def release(to: LockMarker): ListenerLock | Null = inner
 
   /** Maps the lock of a listener, if it exists. */
   inline def withLock[T](listener: Listener[?])(inline body: ListenerLock => T): T | Null =
@@ -167,5 +112,6 @@ object Listener:
 
     protected def acquireLock() = lock0.lock()
     protected def releaseLock() = lock0.unlock()
+
   object NumberedLock:
     private val listenerNumber = java.util.concurrent.atomic.AtomicLong()

--- a/shared/src/main/scala/async/Listener.scala
+++ b/shared/src/main/scala/async/Listener.scala
@@ -35,7 +35,7 @@ trait Listener[-T]:
     * [[release]] is automatically called.
     */
   def completeNow(data: T, source: Async.Source[T]): Boolean =
-    if lockCompletely() then
+    if acquireLock() then
       this.complete(data, source)
       true
     else false
@@ -44,10 +44,10 @@ trait Listener[-T]:
   inline final def releaseLock(): Unit = if lock != null then lock.release()
 
   /** Attempts to completely lock the listener, if such a lock exists. Succeeds with [[true]] immediately if there is no
-    * [[Listener.ListenerLock]]. If locking fails, [[releaseAll]] is automatically called.
+    * [[Listener.ListenerLock]]. If locking fails, [[release]] is automatically called.
     */
-  inline final def lockCompletely(): Boolean =
-    if lock != null then lock.lockSelf() else true
+  inline final def acquireLock(): Boolean =
+    if lock != null then lock.acquire() else true
 
 object Listener:
   /** A simple [[Listener]] that always accepts the item and sends it to the consumer. */
@@ -89,7 +89,7 @@ object Listener:
 
     /** Attempt to lock the current [[ListenerLock]]. Locks are guaranteed to be held as short as possible.
       */
-    def lockSelf(): Boolean
+    def acquire(): Boolean
 
     /** Release the current lock without resolving the listener with any items, if the current listener lock is before
       * or the same as the current [[Listener.LockMarker]].

--- a/shared/src/main/scala/async/channels.scala
+++ b/shared/src/main/scala/async/channels.scala
@@ -280,8 +280,8 @@ object Channel:
         false
 
       private inline def tryComplete(src: CanSend, s: Sender)(r: Reader): s.type | r.type | Unit =
-        lockBoth(readSource, src)(r, s) match
-          case Listener.Locked =>
+        lockBoth(r, s) match
+          case true =>
             Impl.this.complete(src, r, s)
             dequeue() // drop completed reader/sender from queue
             ()

--- a/shared/src/main/scala/async/listeners/locking.scala
+++ b/shared/src/main/scala/async/listeners/locking.scala
@@ -2,7 +2,7 @@
 package gears.async.listeners
 
 import gears.async._
-import Listener.{Locked, ListenerLock, Gone, PartialLock, LockMarker, LockResult}
+import Listener.ListenerLock
 import scala.annotation.tailrec
 
 /** Two listeners being locked at the same time, while holding the same lock on their listener chains. This happens if
@@ -10,8 +10,7 @@ import scala.annotation.tailrec
   * race.
   */
 case class ConflictingLocksException(
-    base: (Listener[?], Listener[?]),
-    conflict: ((ListenerLock | PartialLock), (ListenerLock | PartialLock))
+    listeners: (Listener[?], Listener[?])
 ) extends Exception
 
 /** Attempt to lock both listeners belonging to possibly different sources at the same time. Lock orders are respected
@@ -22,71 +21,25 @@ case class ConflictingLocksException(
   * In the case that two locks sharing the same number is encountered, [[ConflictingLocksException]] is thrown with the
   * base listeners and conflicting listeners.
   */
-def lockBoth[T, U](st: Async.Source[T], su: Async.Source[U])(
+def lockBoth[T, U](
     lt: Listener[T],
     lu: Listener[U]
-): lt.type | lu.type | Locked.type =
-  /* Step 1: weed out non-locking listeners */
-  inline def lockedOr[V >: Locked.type](cause: lt.type | lu.type)(inline body: V) =
-    if body == Locked then Locked else cause
-  val tlt = lt.lock match
-    case tl: ListenerLock => tl
-    case null             => return lockedOr(lu) { lu.lockCompletely(su) }
-  val tlu = lu.lock match
-    case tl: ListenerLock => tl
-    case null             => return lockedOr(lt) { lt.lockCompletely(st) }
+): lt.type | lu.type | true =
+  val lockT = if lt.lock == null then return (if lu.lockCompletely() then true else lu) else lt.lock
+  val lockU = if lu.lock == null then return (if lt.lockCompletely() then true else lt) else lu.lock
 
-  /* Attempts to advance locking one by one. */
-  @tailrec
-  def loop(mt: LockMarker, mu: LockMarker): lt.type | lu.type | Locked.type =
-    inline def advanceSu(su: PartialLock): lt.type | lu.type | Locked.type = su.lockNext() match
-      case Gone          => { tlt.releaseAll(mt); tlu.releaseAll(mu); lu }
-      case v: LockMarker => loop(mt, v)
-    (mt, mu) match
-      case (Locked, Locked)          => Locked
-      case (Locked, su: PartialLock) => advanceSu(su)
-      case (st: PartialLock, su: PartialLock) if st.nextNumber == su.nextNumber =>
-        tlt.releaseAll(mt); tlu.releaseAll(mu)
-        throw ConflictingLocksException((lt, lu), (st, su))
-      case (st: PartialLock, su: PartialLock) if st.nextNumber < su.nextNumber => advanceSu(su)
-      case (st: PartialLock, _) =>
-        st.lockNext() match
-          case Gone          => { tlt.releaseAll(mt); tlu.releaseAll(mu); lt }
-          case v: LockMarker => loop(v, mu)
+  inline def doLock[T, U](lt: Listener[T], lu: Listener[U])(
+      lockT: ListenerLock,
+      lockU: ListenerLock
+  ): lt.type | lu.type | true =
+    // assert(lockT.number > lockU.number)
+    if !lockT.lockSelf() then lt
+    else if !lockU.lockSelf() then
+      lockT.release()
+      lu
+    else true
 
-  /* Attempt to lock the ListenerLock and advance until we start needing to lock the other one. */
-  inline def lockUntilLessThan(other: ListenerLock)(src: Async.Source[?], tl: ListenerLock): LockResult =
-    @tailrec def loop(v: LockMarker): LockResult =
-      v match
-        case Locked => Locked
-        case v: PartialLock if v.nextNumber == other.selfNumber =>
-          tl.releaseAll(v)
-          throw ConflictingLocksException((lt, lu), if lt.lock == other then (other, v) else (v, other))
-        case v: PartialLock if v.nextNumber < other.selfNumber => v
-        case v: PartialLock =>
-          v.lockNext() match
-            case Gone          => tl.releaseAll(v); Gone
-            case m: LockMarker => loop(m)
-    tl.lockSelf(src) match
-      case Gone          => Gone
-      case m: LockMarker => loop(m)
-
-  /* We have to do the first locking step manually. */
-  if tlt.selfNumber == tlu.selfNumber then throw ConflictingLocksException((lt, lu), (tlt, tlu))
-  else if tlt.selfNumber > tlu.selfNumber then
-    val mt = lockUntilLessThan(tlu)(st, tlt) match
-      case Gone          => return lt
-      case v: LockMarker => v
-    val mu = tlu.lockSelf(su) match
-      case Gone          => { tlt.releaseAll(mt); return lu }
-      case v: LockMarker => v
-    loop(mt, mu)
-  else
-    val mu = lockUntilLessThan(tlt)(su, tlu) match
-      case Gone          => return lu
-      case v: LockMarker => v
-    val mt = tlt.lockSelf(st) match
-      case Gone          => { tlu.releaseAll(mu); return lt }
-      case v: LockMarker => v
-    loop(mt, mu)
+  if lockT.selfNumber == lockU.selfNumber then throw ConflictingLocksException((lt, lu))
+  else if lockT.selfNumber > lockU.selfNumber then doLock(lt, lu)(lockT, lockU)
+  else doLock(lu, lt)(lockU, lockT)
 end lockBoth

--- a/shared/src/main/scala/async/listeners/locking.scala
+++ b/shared/src/main/scala/async/listeners/locking.scala
@@ -25,16 +25,16 @@ def lockBoth[T, U](
     lt: Listener[T],
     lu: Listener[U]
 ): lt.type | lu.type | true =
-  val lockT = if lt.lock == null then return (if lu.lockCompletely() then true else lu) else lt.lock
-  val lockU = if lu.lock == null then return (if lt.lockCompletely() then true else lt) else lu.lock
+  val lockT = if lt.lock == null then return (if lu.acquireLock() then true else lu) else lt.lock
+  val lockU = if lu.lock == null then return (if lt.acquireLock() then true else lt) else lu.lock
 
   inline def doLock[T, U](lt: Listener[T], lu: Listener[U])(
       lockT: ListenerLock,
       lockU: ListenerLock
   ): lt.type | lu.type | true =
     // assert(lockT.number > lockU.number)
-    if !lockT.lockSelf() then lt
-    else if !lockU.lockSelf() then
+    if !lockT.acquire() then lt
+    else if !lockU.acquire() then
       lockT.release()
       lu
     else true

--- a/shared/src/test/scala/ListenerBehavior.scala
+++ b/shared/src/test/scala/ListenerBehavior.scala
@@ -252,7 +252,7 @@ class ListenerBehavior extends munit.FunSuite:
     Thread
       .ofPlatform()
       .start: () =>
-        val result = wrapped.lock.lockSelf(source1).asInstanceOf[Listener.PartialLock]
+        val result = wrapped.lock.lockSelf(source1).asInstanceOf[Listener.LockMarker]
         wrapped.releaseLock(result)
       .join()
 

--- a/shared/src/test/scala/ListenerBehavior.scala
+++ b/shared/src/test/scala/ListenerBehavior.scala
@@ -7,13 +7,8 @@ import gears.async.default.given
 import scala.util.Success
 import java.util.concurrent.atomic.AtomicBoolean
 import gears.async.listeners.lockBoth
-import gears.async.Listener.Locked
-import gears.async.Listener.Gone
 import gears.async.Listener.ListenerLock
 import gears.async.Async.Source
-import gears.async.Listener.LockMarker
-import gears.async.Listener.LockResult
-import gears.async.Listener.PartialLock
 import scala.collection.mutable.Buffer
 import gears.async.listeners.ConflictingLocksException
 
@@ -32,7 +27,7 @@ class ListenerBehavior extends munit.FunSuite:
   test("lock two listeners"):
     val listener1 = Listener.acceptingListener[Int]((x, _) => assertEquals(x, 1))
     val listener2 = Listener.acceptingListener[Int]((x, _) => assertEquals(x, 2))
-    assertEquals(lockBoth(Dummy, Dummy)(listener1, listener2), Locked)
+    assertEquals(lockBoth(listener1, listener2), true)
     listener1.complete(1, Dummy)
     listener2.complete(2, Dummy)
 
@@ -42,15 +37,14 @@ class ListenerBehavior extends munit.FunSuite:
       val lock = null
       def complete(data: Nothing, src: Async.Source[Nothing]): Unit =
         fail("should not succeed")
-      def release(until: Listener.LockMarker) =
+      def release() =
         listener1Locked = false
-        null
     val listener2 = NumberedTestListener(false, true, 1)
 
-    assertEquals(lockBoth(Dummy, Dummy)(listener1, listener2), listener2)
+    assertEquals(lockBoth(listener1, listener2), listener2)
     assert(!listener1Locked)
 
-    assertEquals(lockBoth(Dummy, Dummy)(listener2, listener1), listener2)
+    assertEquals(lockBoth(listener2, listener1), listener2)
     assert(!listener1Locked)
 
   test("lock two races"):
@@ -60,7 +54,7 @@ class ListenerBehavior extends munit.FunSuite:
     Async.race(source1).onComplete(Listener.acceptingListener[Int]((x, _) => assertEquals(x, 1)))
     Async.race(source2).onComplete(Listener.acceptingListener[Int]((x, _) => assertEquals(x, 2)))
 
-    assertEquals(lockBoth(source1, source2)(source1.listener.get, source2.listener.get), Locked)
+    assertEquals(lockBoth(source1.listener.get, source2.listener.get), true)
     source1.completeWith(1)
     source2.completeWith(2)
 
@@ -71,7 +65,7 @@ class ListenerBehavior extends munit.FunSuite:
     Async.race(source1).onComplete(Listener.acceptingListener[Int]((x, _) => assertEquals(x, 1)))
     Async.race(source2).onComplete(Listener.acceptingListener[Int]((x, _) => assertEquals(x, 2)))
 
-    assertEquals(lockBoth(source1, source2)(source2.listener.get, source1.listener.get), Locked)
+    assertEquals(lockBoth(source2.listener.get, source1.listener.get), true)
     source1.completeWith(1)
     source2.completeWith(2)
 
@@ -83,7 +77,7 @@ class ListenerBehavior extends munit.FunSuite:
     Async.race(Async.race(source2)).onComplete(Listener.acceptingListener[Int]((x, _) => assertEquals(x, 2)))
     Async.race(race1).onComplete(Listener.acceptingListener[Int]((x, _) => assertEquals(x, 1)))
 
-    assertEquals(lockBoth(source1, source2)(source1.listener.get, source2.listener.get), Locked)
+    assertEquals(lockBoth(source1.listener.get, source2.listener.get), true)
     source1.completeWith(1)
     source2.completeWith(2)
 
@@ -95,7 +89,7 @@ class ListenerBehavior extends munit.FunSuite:
     Async.race(Async.race(source2)).onComplete(Listener.acceptingListener[Int]((x, _) => assertEquals(x, 2)))
     Async.race(race1).onComplete(Listener.acceptingListener[Int]((x, _) => assertEquals(x, 1)))
 
-    assertEquals(lockBoth(source2, source1)(source2.listener.get, source1.listener.get), Locked)
+    assertEquals(lockBoth(source2.listener.get, source1.listener.get), true)
     source1.completeWith(1)
     source2.completeWith(2)
 
@@ -108,12 +102,12 @@ class ListenerBehavior extends munit.FunSuite:
     assert(source1.listener.isDefined)
     assert(source2.listener.isDefined)
 
-    val lock = source1.listener.get.lockCompletely(source1)
-    assertEquals(lock, Locked)
+    val lock = source1.listener.get.lockCompletely()
+    assertEquals(lock, true)
 
     Async.blocking:
       val l2 = source2.listener.get
-      val f = Future(assertEquals(l2.lockCompletely(source2), Gone))
+      val f = Future(assertEquals(l2.lockCompletely(), false))
       source1.completeWith(1)
       assert(source1.listener.isEmpty)
       assert(source2.listener.isEmpty)
@@ -155,7 +149,7 @@ class ListenerBehavior extends munit.FunSuite:
     val listener = NumberedTestListener(false, true, 1)
     Async.race(source1, source2).onComplete(listener)
 
-    assertEquals(source1.lockListener(), Gone)
+    assertEquals(source1.lockListener(), false)
     assert(source1.listener.isEmpty)
     assert(source2.listener.isEmpty)
 
@@ -168,34 +162,11 @@ class ListenerBehavior extends munit.FunSuite:
     val s1listener = source1.listener.get
 
     Async.blocking:
-      val f1 = Future(lockBoth(source1, Dummy)(s1listener, other))
+      val f1 = Future(lockBoth(s1listener, other))
       other.waitWaiter()
       assert(source2.listener.get.completeNow(1, source2))
       other.continue()
       assertEquals(f1.await, s1listener)
-
-  test("lockBoth ordering"):
-    val ordering = Buffer[Long]()
-    val src = TSource()
-    val l = TestListener(1)
-    val s1 = lockChain(ordering, l)(5, 3, 1)
-    val s2 = lockChain(ordering, l)(4, 2)
-
-    assertEquals(lockBoth(src, src)(s1, s2), Locked)
-    assertEquals(ordering.toSeq, Seq(5L, 4, 3, 2, 1))
-    ordering.clear()
-    assertEquals(lockBoth(src, src)(s2, s1), Locked)
-    assertEquals(ordering.toSeq, Seq(5L, 4, 3, 2, 1))
-
-    val s3 = lockChain(ordering, l)(5, 4, 1)
-    val s4 = lockChain(ordering, l)(3, 2)
-
-    ordering.clear()
-    assertEquals(lockBoth(src, src)(s3, s4), Locked)
-    assertEquals(ordering.toSeq, Seq(5L, 4, 3, 2, 1))
-    ordering.clear()
-    assertEquals(lockBoth(src, src)(s4, s3), Locked)
-    assertEquals(ordering.toSeq, Seq(5L, 4, 3, 2, 1))
 
   test("conflicting locks"):
     val l = NumberedTestListener(false, false, 1)
@@ -207,56 +178,36 @@ class ListenerBehavior extends munit.FunSuite:
       r.onComplete(l)
       src.listener.get
     })
-    val (k1, k2) =
-      try
-        lockBoth(s1, s2)(l1, l2)
-        ???
-      catch
-        case ConflictingLocksException(base, conflict) =>
-          assertEquals(base, (l1, l2))
-          conflict
     try
-      lockBoth(s2, s1)(l2, l1)
+      lockBoth(l1, l2)
       ???
     catch
-      case ConflictingLocksException(base, conflict) =>
+      case ConflictingLocksException(base) =>
+        assertEquals(base, (l1, l2))
+    try
+      lockBoth(l2, l1)
+      ???
+    catch
+      case ConflictingLocksException(base) =>
         assertEquals(base, (l2, l1))
-        assertEquals(conflict, (k2, k1))
     try
-      lockBoth(s1, s2)(l, l2)
+      lockBoth(l, l2)
       ???
     catch
-      case ConflictingLocksException(base, conflict) =>
+      case ConflictingLocksException(base) =>
         assertEquals(base, (l, l2))
-        assertEquals(conflict, (l.lock, k2))
     try
-      lockBoth(s1, s2)(l1, l)
+      lockBoth(l1, l)
       ???
     catch
-      case ConflictingLocksException(base, conflict) =>
+      case ConflictingLocksException(base) =>
         assertEquals(base, (l1, l))
-        assertEquals(conflict, (k1, l.lock))
     try
-      lockBoth(s1, s2)(l, l)
+      lockBoth(l, l)
       ???
     catch
-      case ConflictingLocksException(base, conflict) =>
+      case ConflictingLocksException(base) =>
         assertEquals(base, (l, l))
-        assertEquals(conflict, (l.lock, l.lock))
-
-  test("unlocking midway releases locks"):
-    val source1 = TSource()
-    Async.race(source1).onComplete(NumberedTestListener(false, false, 1))
-    val wrapped = source1.listener.get
-
-    Thread
-      .ofPlatform()
-      .start: () =>
-        val result = wrapped.lock.lockSelf(source1).asInstanceOf[Listener.LockMarker]
-        wrapped.releaseLock(result)
-      .join()
-
-    assert(wrapped.completeNow(1, source1))
 
   test("failing downstream listener is dropped in race"):
     val source1 = TSource()
@@ -288,28 +239,6 @@ class ListenerBehavior extends munit.FunSuite:
     assert(source2.listener.isEmpty)
     assert(source3.listener.isEmpty)
 
-def lockChain[T](buf: Buffer[Long], inner: Listener[T])(numbers: Long*) =
-  def wrap(num: Long, inner: Listener[T]) = new Listener[T] {
-    override val lock: ListenerLock | Null = new ListenerLock {
-      override val selfNumber: Long = num
-      var heldSrc: Source[?] = null
-      val partialLock = Listener.withLock(inner): innerLock =>
-        new PartialLock:
-          override val nextNumber: Long = innerLock.selfNumber
-          override def lockNext(): LockResult = innerLock.lockSelf(heldSrc)
-      override def lockSelf(source: Source[?]): LockResult =
-        heldSrc = source
-        buf += num
-        partialLock match
-          case null            => Locked
-          case pl: PartialLock => pl
-      override protected def release(to: LockMarker): ListenerLock | Null =
-        if to == partialLock then null else inner.lock
-    }
-    override def complete(data: T, source: Source[T]): Unit = ???
-  }
-  numbers.foldRight(inner)(wrap)
-
 private class TestListener(expected: Int)(using asst: munit.Assertions) extends Listener[Int]:
   val lock = null
 
@@ -317,16 +246,15 @@ private class TestListener(expected: Int)(using asst: munit.Assertions) extends 
     asst.assertEquals(data, expected)
 
 private class NumberedTestListener private (sleep: AtomicBoolean, fail: Boolean, expected: Int)(using munit.Assertions)
-    extends TestListener(expected)
-    with Listener.NumberedLock:
+    extends TestListener(expected):
   private var waiter: Option[Promise[Unit]] = None
 
   def this(sleep: Boolean, fail: Boolean, expected: Int)(using munit.Assertions) =
     this(AtomicBoolean(sleep), fail, expected)
 
-  override val lock = new ListenerLock:
-    val selfNumber = NumberedTestListener.this.number
-    def lockSelf(source: Source[?]) =
+  override val lock = new ListenerLock with Listener.NumberedLock:
+    val selfNumber = this.number
+    def lockSelf() =
       if sleep.getAndSet(false) then
         Async.blocking:
           waiter = Some(Promise())
@@ -334,9 +262,9 @@ private class NumberedTestListener private (sleep: AtomicBoolean, fail: Boolean,
       waiter.foreach: promise =>
         promise.complete(Success(()))
         waiter = None
-      if fail then Listener.Gone
-      else Listener.Locked
-    protected def release(to: LockMarker): ListenerLock | Null = null
+      if fail then false
+      else true
+    def release() = ()
 
   def waitWaiter() =
     while waiter.isEmpty do Thread.`yield`()
@@ -360,8 +288,8 @@ private class TSource(using asst: munit.Assertions) extends Async.Source[Int]:
       asst.assertEquals(k, listener.get)
       listener = None
   def lockListener() =
-    val r = listener.get.lockCompletely(this)
-    if r == Listener.Gone then listener = None
+    val r = listener.get.lockCompletely()
+    if !r then listener = None
     r
   def completeWith(value: Int) =
     val l = listener.get


### PR DESCRIPTION
Upon discussions with @m8nmueller, we discovered that `race` does not necessarily require nested locking of
listeners (which is the only usage of the nested locks).
Instead the `race` implementation can just re-use the upsteam listener's lock and provide one if not yet existed.

With this out, I think we can just remove all the nested locking mechanisms. Should a legitimate need is raised
again in the future, we know that there is a sound and performant design ready.

Progress:
- Make race utilize existing upstream lock if possible
- Remove nested locks
- Rename lockCompletely -> acquireLock, lockSelf -> acquire
