### PR TITLE
Provide a simple Nix Flake development environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,9 @@
 `gears` currently require:
 - **On the JVM**: JVM with support for virtual threads. This usually means JVM 21+, or 19+ with `--enable-preview`.
 - **On Scala Native**: Scala Native with delimited continuations support. See the pinned versions in [`dependencies`](./dependencies/README.md).
+
+All of the needed dependencies can be loaded by the included Nix Flake. If you have `nix` with `flake` enabled, run
+```
+nix develop
+```
+to enter the development environment with all the dependencies loaded. You can also use [direnv](https://direnv.net/)'s `use flake` to automate this process.

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -4,8 +4,14 @@ Scala Native requires some libraries to be compiled from source and `publishLoca
 
 ### TL; DR
 
+You need to have all the [dependencies to build Scala Native](https://scala-native.org/en/stable/user/setup.html). Run:
 ```bash
 ./publish-deps.sh
+```
+
+Or if you have `nix` with `flake` enabled, run the following from this repo's root:
+```
+nix develop .#dependencies -c dependencies/publish-deps.sh
 ```
 
 ### What are included?

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708118438,
+        "narHash": "sha256-kk9/0nuVgA220FcqH/D2xaN6uGyHp/zoxPNUmPCMmEE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5863c27340ba4de8f83e7e3c023b9599c3cb3c80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "Flake for lampepfl/gears";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ ];
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        # Per-system attributes can be defined here. The self' and inputs'
+        # module parameters provide easy access to attributes of the same
+        # system.
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Scala deps
+            (sbt.override { jre = jdk21; })
+            # Scala Native deps
+            llvm
+            clang
+            boehmgc
+            libunwind
+            zlib
+            # Dev deps
+            metals
+            scalafix
+            scalafmt
+          ];
+          shellHook = ''
+            export LLVM_BIN=${pkgs.clang}/bin
+          '';
+        };
+        # To be used to build `scala-native` and `munit`, as JDK21 + scala-native is not yet doing so well.
+        devShells.dependencies = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Scala deps
+            (sbt.override { jre = jdk17; })
+            # Scala Native deps
+            llvm
+            clang
+            boehmgc
+            libunwind
+            zlib
+          ];
+        };
+      };
+      flake = {
+        # The usual flake attributes can be defined here, including system-
+        # agnostic ones like nixosModule and system-enumerating ones, although
+        # those are more easily expressed in perSystem.
+      };
+    };
+}


### PR DESCRIPTION
The flake includes all dependencies to build `scala-native` as well as gears itself.

- Add a basic flake
- Update instructions for nix users
