### PR TITLE
Introduce `Retry` as an alternative to Tasks 

### DIFF
--- a/shared/src/main/scala/async/AsyncOperations.scala
+++ b/shared/src/main/scala/async/AsyncOperations.scala
@@ -1,8 +1,31 @@
 package gears.async
 
+import scala.concurrent.duration.Duration
+import java.util.concurrent.TimeoutException
+import gears.async.AsyncOperations.sleep
+
 trait AsyncOperations:
   def sleep(millis: Long)(using Async): Unit
 
 object AsyncOperations:
   inline def sleep(millis: Long)(using AsyncOperations, Async): Unit =
     summon[AsyncOperations].sleep(millis)
+
+/** Runs [[op]] with a timeout. When the timeout occurs, [[op]] is cancelled through the given [[Async]] context, and
+  * [[TimeoutException]] is thrown.
+  */
+def withTimeout[T](timeout: Duration)(op: Async ?=> T)(using Async, AsyncOperations): T =
+  Async.select(
+    Future(op).handle(_.get),
+    Future(sleep(timeout.toMillis)).handle: _ =>
+      throw TimeoutException()
+  )
+
+/** Runs [[op]] with a timeout. When the timeout occurs, [[op]] is cancelled through the given [[Async]] context, and
+  * [[None]] is returned.
+  */
+def withTimeoutOption[T](timeout: Duration)(op: Async ?=> T)(using Async, AsyncOperations): Option[T] =
+  Async.select(
+    Future(op).handle(v => Some(v.get)),
+    Future(sleep(timeout.toMillis)).handle(_ => None)
+  )

--- a/shared/src/main/scala/async/retry.scala
+++ b/shared/src/main/scala/async/retry.scala
@@ -1,0 +1,77 @@
+package gears.async
+
+import scala.concurrent.duration._
+import scala.util.Try
+import scala.util.control.NonFatal
+import scala.util.Failure
+import scala.util.Success
+import gears.async.AsyncOperations.sleep
+import scala.util.Random
+
+case class Retry(
+    retryOnSuccess: Boolean = false,
+    maximumFailures: Option[Int] = None,
+    delay: Delay = Delay.none
+):
+  def apply[T](op: => T)(using Async, AsyncOperations): T =
+    @scala.annotation.tailrec
+    def loop(failures: Int, lastDelay: Duration): T =
+      Try(op) match
+        case Failure(exception) =>
+          if maximumFailures.exists(_ == failures) then // maximum failure count reached
+            throw exception
+          else
+            val toSleep = delay.delayFor(failures + 1, lastDelay)
+            sleep(toSleep.toMillis)
+            loop(failures + 1, toSleep)
+        case Success(value) =>
+          if retryOnSuccess then
+            sleep(delay.delayFor(0, 0.second).toMillis)
+            loop(0, 0.second)
+          else value
+
+    loop(0, 0.seconds)
+
+  def withMaximumFailures(max: Int) =
+    assert(max >= 0)
+    this.copy(maximumFailures = Some(max))
+
+  def withDelay(delay: Delay) = this.copy(delay = delay)
+
+object Retry:
+  val forever = Retry(retryOnSuccess = true)
+  val untilSuccess = Retry(retryOnSuccess = false)
+  val untilFailure = Retry(retryOnSuccess = true).withMaximumFailures(0)
+
+trait Delay:
+  def delayFor(failuresCount: Int, lastDelay: Duration): Duration
+
+object Delay:
+  val none = constant(0.second)
+
+  def constant(duration: Duration) = new Delay:
+    def delayFor(failuresCount: Int, lastDelay: Duration): Duration = duration
+
+  trait Jitter:
+    def jitterDelay(last: Duration, maximum: Duration): Duration
+
+  object Jitter:
+    val none = new Jitter:
+      def jitterDelay(last: Duration, maximum: Duration): Duration = maximum
+    val equal = new Jitter:
+      def jitterDelay(last: Duration, maximum: Duration): Duration =
+        val base = maximum.toMillis / 2
+        (base + Random.between(0, base)).millis
+    def decorrelated(base: Duration, multiplier: Double = 3) = new Jitter:
+      def jitterDelay(last: Duration, maximum: Duration): Duration =
+        Random.between(base.toMillis, (last.toMillis * multiplier).toLong).millis
+
+  def backoff(maximum: Duration, starting: Duration, multiplier: Double = 2, jitter: Jitter = Jitter.none) = new Delay:
+    def delayFor(failuresCount: Int, lastDelay: Duration): Duration =
+      jitter
+        .jitterDelay(
+          lastDelay,
+          if failuresCount <= 1 then starting
+          else (lastDelay.toMillis * multiplier).toLong.millis
+        )
+        .min(maximum)

--- a/shared/src/test/scala/RetryBehavior.scala
+++ b/shared/src/test/scala/RetryBehavior.scala
@@ -1,4 +1,5 @@
-import gears.async.{Async, Future, Task, TaskSchedule, Retry, Delay}
+import gears.async.{Async, Future, Task, TaskSchedule, Retry}
+import Retry.Delay
 import scala.concurrent.duration.*
 import gears.async.default.given
 import Future.{*:, zip}

--- a/shared/src/test/scala/RetryBehavior.scala
+++ b/shared/src/test/scala/RetryBehavior.scala
@@ -1,6 +1,7 @@
 import gears.async.{Async, Future, Task, TaskSchedule, Retry}
 import Retry.Delay
 import scala.concurrent.duration.*
+import FiniteDuration as Duration
 import gears.async.default.given
 import Future.{*:, zip}
 

--- a/shared/src/test/scala/RetryBehavior.scala
+++ b/shared/src/test/scala/RetryBehavior.scala
@@ -1,0 +1,53 @@
+import gears.async.{Async, Future, Task, TaskSchedule, Retry, Delay}
+import scala.concurrent.duration.*
+import gears.async.default.given
+import Future.{*:, zip}
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
+import scala.util.Random
+
+class RetryBehavior extends munit.FunSuite {
+  test("Exponential backoff(2) 50ms, 5 times total schedule"):
+    val start = System.currentTimeMillis()
+    Async.blocking:
+      var i = 0
+      Retry.untilSuccess.withDelay(Delay.backoff(1.second, 50.millis)):
+        i += 1
+        if i < 5 then throw Exception("try again!")
+    val end = System.currentTimeMillis()
+    assert(end - start >= 50 + 100 + 200 + 400)
+    assert(end - start < 50 + 100 + 200 + 400 + 800)
+
+  test("UntilSuccess 150ms"):
+    val start = System.currentTimeMillis()
+    Async.blocking:
+      var i = 0
+      val ret = Retry.untilSuccess.withDelay(Delay.constant(150.millis)):
+        if (i < 4) then
+          i += 1
+          throw AssertionError()
+        else i
+      assertEquals(ret, 4)
+    val end = System.currentTimeMillis()
+    assert(end - start >= 4 * 150)
+    assert(end - start < 5 * 150)
+
+  test("UntilFailure 150ms") {
+    val start = System.currentTimeMillis()
+    val ex = AssertionError()
+    Async.blocking:
+      var i = 0
+      val ret = Try(Retry.untilFailure.withDelay(Delay.constant(150.millis)):
+        if (i < 4) then
+          i += 1
+          i
+        else throw ex
+      )
+      assertEquals(ret, Failure(ex))
+    val end = System.currentTimeMillis()
+    assert(end - start >= 4 * 150)
+    assert(end - start < 5 * 150)
+  }
+
+}


### PR DESCRIPTION
## What is this?

This PR proposes a new API for handling retries and timeouts.

### The `Task` abstraction

The `Task` abstraction represents "Future templates", or, referential transparent
wrappers around asynchronous code that can be turned into a `Future` by `run`ning them.
While this is from a theoretical stand-point a good feature to include, when using
`gears` I find them not very useful as-is, since the alternative of just directly
using `Async ?=> T` function types is both more straightforward and easier to compose.

`Task`s however provide a good story about _managing asynchronous tasks_, which includes
running them with timeouts and a retry policy (including exponential back-offs, attempt counting etc.).
Unfortunately I don't think the API presented by `Task` currently is very nice at doing so:
- `Task` requires you to provide the _operation_ before the _policy_, making chaining awkward:
  ```scala
    val task = Task:
        // asynchronous operation
      .schedule(TaskSchedule.Backoff(...)) // Task[T]
      .run // Future[T]
  ```
- Also, chaining `Task.schedule` creates a new `Task` with opaque scheduling policies, making it difficult
  to inspect which has been applied, as well as making it simple to accidentally nest scheduling policies
  (something I believe is never intended).
- Running a `Task` *requires* it to create a _running_ `Future[T]`, which specifically violates the high-level
  structured concurrency API design of `gears`, forcing the user to remember another possible point of introducing
  dangling, unstructured Futures.
  (This, however, could've been easily remedied by just making `.run` a blocking/suspending operation.)

### The `Retry` API

In contrast, the `Retry` API provides up-front declaration of the retrying policy, and lets the user specify the operation
_at the last moment_:

```scala
class Retry:
    def apply[T](body: => T)(using Async): T // blocking, runs `body` with the configured Retry policy
```

while allowing the user to build up the `Retry` policy by method chaining:

```scala
Retry
  .untilSuccess
  .withMaximumFailures(5)
  .withDelay(Delay.backoff(starting = 5.millis, maximum = 1.second)):
     // the operation
```

This API intentionally does not deal with encapsulating async operations in any way: the call is supposed to be
blocking, so it is safe to capture the enclosing `Async` instance.

Currently `Retry` supports:
- [x] `forever`, an infinite loop on the operation, with possible delays in between.
  - Note that `boundary` can be used to force an early break.
- [x] `untilSuccess` and `untilFailure`.
- Delay policies are open through the `Retry.Delay` trait, but some default implementations are provided: no delays, constant delays and exponential backoff (with jittering).

### Sidenote: `withTimeout`

This PR also adds a simple `withTimeout` function that runs an asynchronous operation with a given timeout.
This can be manually implemented by running the operation in a `Future` and racing it a `Timer` (or another sleeping future),
however I think this is a worthy addition to the standard operations, and will probably need some support once #46 lands.

## Progress
- [x] Add a `Retry` module that performs operations with delays
- [x] Add documentation
