### PR TITLE
Async primitives

### DIFF
--- a/shared/src/main/scala/async/Async.scala
+++ b/shared/src/main/scala/async/Async.scala
@@ -318,14 +318,14 @@ object Async:
                 def acquire() =
                   if found then false
                   else
-                    acquireLock()
+                    numberedLock.lock()
                     if found then
-                      releaseLock()
+                      numberedLock.unlock()
                       // no cleanup needed here, since we have done this by an earlier `complete` or `lockNext`
                       false
                     else true
                 def release() =
-                  releaseLock()
+                  numberedLock.unlock()
 
           var found = false
 

--- a/shared/src/main/scala/async/Listener.scala
+++ b/shared/src/main/scala/async/Listener.scala
@@ -2,6 +2,7 @@ package gears.async
 
 import gears.async.Async.Source
 
+import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 import scala.annotation.tailrec
 
@@ -100,11 +101,8 @@ object Listener:
   trait NumberedLock:
     import NumberedLock._
 
-    val number = listenerNumber.getAndIncrement()
-    private val lock0 = ReentrantLock()
-
-    protected def acquireLock() = lock0.lock()
-    protected def releaseLock() = lock0.unlock()
+    protected val number = listenerNumber.getAndIncrement()
+    protected val numberedLock: Lock = ReentrantLock()
 
   object NumberedLock:
     private val listenerNumber = java.util.concurrent.atomic.AtomicLong()

--- a/shared/src/main/scala/async/Resource.scala
+++ b/shared/src/main/scala/async/Resource.scala
@@ -1,0 +1,166 @@
+package gears.async
+
+/** A Resource wraps allocation to some asynchronously allocatable and releasable resource and grants access to it. It
+  * allows both structured access (similar to [[scala.util.Using]]) and unstructured allocation.
+  */
+trait Resource[+T]:
+  self =>
+
+  /** Run a structured action on the resource. It is allocated and released automatically.
+    *
+    * @param body
+    *   the action to run on the resource
+    * @return
+    *   the result of [[body]]
+    */
+  def use[V](body: T => V)(using Async): V =
+    val res = allocated
+    try body(res._1)
+    finally res._2
+
+  /** Allocate the resource and leak it. **Use with caution**. The programmer is responsible for closing the resource
+    * with the returned handle.
+    *
+    * @return
+    *   the allocated access to the resource data as well as a handle to close it
+    */
+  def allocated(using Async): (T, Async ?=> Unit)
+
+  /** Create a derived resource that inherits the close operation.
+    *
+    * @param fn
+    *   the function used to transform the resource data. It is only run on allocation/use.
+    * @return
+    *   the transformed resource used to access the mapped resource data
+    */
+  def map[U](fn: T => Async ?=> U): Resource[U] = new Resource[U]:
+    override def use[V](body: U => V)(using Async): V = self.use(t => body(fn(t)))
+    override def allocated(using Async): (U, (Async) ?=> Unit) =
+      val res = self.allocated
+      try
+        (fn(res._1), res._2)
+      catch
+        e =>
+          res._2
+          throw e
+    override def map[Q](fn2: U => (Async) ?=> Q): Resource[Q] = self.map(t => fn2(fn(t)))
+
+  /** Create a derived resource that creates a inner resource from the resource data. The inner resource will be
+    * acquired simultaneously, thus it can both transform the resource data and add a new cleanup action.
+    *
+    * @param fn
+    *   a function that creates an inner resource
+    * @return
+    *   the transformed resource that provides the two-levels-in-one access
+    */
+  def flatMap[U](fn: T => Async ?=> Resource[U]): Resource[U] = new Resource[U]:
+    override def use[V](body: U => V)(using Async): V = self.use(t => fn(t).use(body))
+    override def allocated(using Async): (U, (Async) ?=> Unit) =
+      val res = self.allocated
+      try
+        val mapped = fn(res._1).allocated
+        (
+          mapped._1,
+          { closeAsync ?=>
+            try mapped._2(using closeAsync) // close inner first
+            finally res._2(using closeAsync) // then close second, even if first failed
+          }
+        )
+      catch
+        e =>
+          res._2
+          throw e
+end Resource
+
+object Resource:
+  /** Create a Resource from the allocation and release operation. The returned resource will allocate a new instance,
+    * i.e., call [[alloc]], for every call to [[use]] and [[allocated]].
+    *
+    * @param alloc
+    *   the allocation (generating) operation
+    * @param close
+    *   the release (close) operation
+    * @return
+    *   a new Resource exposing the allocatable object in a safe way
+    */
+  inline def apply[T](inline alloc: Async ?=> T, inline close: T => Async ?=> Unit): Resource[T] =
+    new Resource[T]:
+      def allocated(using Async): (T, (Async) ?=> Unit) =
+        val res = alloc
+        (res, close(res))
+
+  /** Create a concurrent computation resource from an allocator function. It can use the given capability to spawn
+    * [[Future]]s and return a handle to communicate with them. Allocation is only complete after that allocator
+    * returns. The resource is only allocated on use.
+    *
+    * If the [[Async.Spawn]] capability is used for [[Async.await]]ing, it may only be done synchronously by the
+    * spawnBody.
+    *
+    * No presumption is made on reusability of the Resource. Thus, if the [[spawnBody]] is re-runnable, so is the
+    * Resource created from it.
+    *
+    * @param spawnBody
+    *   the allocator to setup and start asynchronous computation
+    * @return
+    *   a new resource wrapping access to the spawnBody's results
+    */
+  inline def spawning[T](inline spawnBody: Async.Spawn ?=> T) = Async.spawning.map(spawn => spawnBody(using spawn))
+
+  /** Create a resource that does not need asynchronous allocation nor cleanup.
+    *
+    * @param data
+    *   the generator that provides the resource element
+    * @return
+    *   a resource wrapping the data provider
+    */
+  inline def just[T](inline data: => T) = apply(data, _ => ())
+
+  /** Create a resource combining access to two separate resources.
+    *
+    * @param res1
+    *   the first resource
+    * @param res2
+    *   the second resource
+    * @param join
+    *   an operator to combine the elements from both resources to that of the combined resource
+    * @return
+    *   a new resource wrapping access to the combined element
+    */
+  def both[T, U, V](res1: Resource[T], res2: Resource[U])(join: (T, U) => V): Resource[V] = new Resource[V]:
+    override def allocated(using Async): (V, (Async) ?=> Unit) =
+      val alloc1 = res1.allocated
+      val alloc2 =
+        try res2.allocated
+        catch
+          e =>
+            alloc1._2
+            throw e
+
+      try
+        val joined = join(alloc1._1, alloc2._1)
+        (
+          joined,
+          { closeAsync ?=>
+            try alloc1._2(using closeAsync)
+            finally alloc2._2(using closeAsync)
+          }
+        )
+      catch
+        e =>
+          try alloc1._2
+          finally alloc2._2
+          throw e
+  end both
+
+  /** Create a resource combining access to a list of resources
+    *
+    * @param ress
+    *   the list of single resources
+    * @return
+    *   the resource of the list of elements provided by the single resources
+    */
+  def all[T](ress: List[Resource[T]]): Resource[List[T]] = ress match
+    case Nil          => just(Nil)
+    case head :: Nil  => head.map(List(_))
+    case head :: next => both(head, all(next))(_ :: _)
+end Resource

--- a/shared/src/main/scala/async/Semaphore.scala
+++ b/shared/src/main/scala/async/Semaphore.scala
@@ -1,0 +1,73 @@
+package gears.async
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+
+/** A semaphore that manages a number of grants. One can wait to obtain a grant (with [[acquire]]) and return it to the
+  * semaphore (with [[release]]).
+  *
+  * @param initialValue
+  *   the initial counter of this semaphore
+  */
+class Semaphore(initialValue: Int) extends Async.Source[Semaphore.Guard]:
+  self =>
+  private val value = AtomicInteger(initialValue)
+  private val waiting = ConcurrentLinkedQueue[Listener[Semaphore.Guard]]()
+
+  override def onComplete(k: Listener[Semaphore.Guard]): Unit =
+    if k.acquireLock() then // if k is gone, we are done
+      if value.getAndDecrement() > 0 then
+        // we got a ticket
+        k.complete(guard, this)
+      else
+        // no ticket -> add to queue and reset value (was now negative - unless concurrently increased)
+        k.releaseLock()
+        waiting.add(k)
+        guard.release()
+
+  override def dropListener(k: Listener[Semaphore.Guard]): Unit = waiting.remove(k)
+
+  override def poll(k: Listener[Semaphore.Guard]): Boolean =
+    if !k.acquireLock() then return true
+    val success = value.getAndUpdate(i => if i > 0 then i - 1 else i) > 0
+    if success then k.complete(guard, self) else k.releaseLock()
+    success
+
+  override def poll(): Option[Semaphore.Guard] =
+    if value.getAndUpdate(i => if i > 0 then i - 1 else i) > 0 then Some(guard) else None
+
+  /** Decrease the number of grants available from this semaphore, possibly waiting if none is available.
+    *
+    * @param a
+    *   the async capability used for waiting
+    */
+  inline def acquire()(using Async): Semaphore.Guard =
+    this.awaitResult // do not short-circuit because cancellation should be considered first
+
+  private object guard extends Semaphore.Guard:
+    /** Increase the number of grants available to this semaphore, possibly waking up a waiting [[acquire]].
+      */
+    def release(): Unit =
+      // if value is < 0, a ticket is missing anyway -> do nothing now
+      if value.getAndUpdate(i => if i < 0 then i + 1 else i) >= 0 then
+        // we kept the ticket for now
+
+        var listener = waiting.poll()
+        while listener != null && !listener.completeNow(guard, self) do listener = waiting.poll()
+        // if listener not null, then we quit because listener was completed -> ticket is reused -> we are done
+
+        // if listener is null, return the ticket by incrementing, then recheck waiting queue (if incremented to >0)
+        if listener == null && value.getAndIncrement() >= 0 then
+          listener = waiting.poll()
+          if listener != null then // if null now, we are done
+            onComplete(listener)
+
+object Semaphore:
+  /** A guard that marks a single usage of the [[Semaphore]]. Implements [[java.lang.AutoCloseable]] so it can be used
+    * as a try-with-resource (e.g. with [[scala.util.Using]]).
+    */
+  trait Guard extends java.lang.AutoCloseable:
+    /** Release the semaphore, must be called exactly once. */
+    def release(): Unit
+
+    final def close() = release()

--- a/shared/src/test/scala/AwaitBehavior.scala
+++ b/shared/src/test/scala/AwaitBehavior.scala
@@ -1,0 +1,124 @@
+import gears.async.Async
+import gears.async.Async.Spawn
+import gears.async.CancellationException
+import gears.async.Future
+import gears.async.Listener
+import gears.async.SyncChannel
+import gears.async.UnboundedChannel
+import gears.async.default.given
+
+import scala.util.Success
+import scala.util.Try
+
+class AwaitBehavior extends munit.FunSuite:
+  given munit.Assertions = this
+
+  class FutHandle(using a: Async, sp: a.type & Async.Spawn):
+    val source = TSource()
+    private var res0 = Future.Promise[Int]()
+    // cancelled Futures complete with CancellationException even if the body terminated -> store result externally
+    private val fut = Future { res0.complete(Try(source.awaitResult)) }
+    while (source.listener.isEmpty) do Thread.`yield`()
+    val listener = source.listener.get
+    val locker = AsyncLocker(listener, source)
+
+    def cancel() = fut.cancel()
+    def res()(using Async) = res0.awaitResult
+
+  test("completion after cancellation"):
+    Async.blocking:
+      val handle = FutHandle()
+      handle.cancel()
+      assert(!handle.locker.completeNow(1))
+      assert(handle.res().failed.filter(_.isInstanceOf[CancellationException]).isSuccess)
+      handle.locker.quit()
+
+  test("cancellation of await during completion"):
+    Async.blocking:
+      val handle = FutHandle()
+      assert(handle.locker.lockAndWait())
+      handle.cancel()
+      handle.locker.complete(1)
+      assertEquals(handle.res(), Success(1))
+      handle.locker.quit()
+
+  test("cancellation of await during lock+release"):
+    Async.blocking:
+      val handle = FutHandle()
+      assert(handle.locker.lockAndWait())
+      handle.cancel()
+      handle.locker.release()
+      assert(handle.res().failed.filter(_.isInstanceOf[CancellationException]).isSuccess)
+      handle.locker.quit()
+
+  test("cancellation of await with contending lock after release"):
+    Async.blocking:
+      val handle = FutHandle()
+      assert(handle.locker.lockAndWait())
+      val fut2 = Future(assert(!handle.listener.acquireLock()))
+      Thread.sleep(100) // cannot detect when fut2 starts waiting for lock
+
+      handle.cancel()
+      handle.locker.release()
+      assert(handle.res().failed.filter(_.isInstanceOf[CancellationException]).isSuccess)
+      fut2.await
+      handle.locker.quit()
+
+  class AsyncLocker(l: Listener[Int], s: Async.Source[Int])(using a: Async, sp: a.type & Async.Spawn):
+    private enum ReqMessage:
+      case Lock
+      case Release
+      case Complete(data: Int)
+      case Quit
+    private enum ResMessage:
+      case LockResult(success: Boolean)
+      case Done
+
+    private val reqCh = SyncChannel[ReqMessage]()
+    private val resCh = UnboundedChannel[ResMessage]() // send never blocks
+
+    def lockAndWait()(using Async) =
+      reqCh.send(ReqMessage.Lock)
+      resCh.read().right.get.asInstanceOf[ResMessage.LockResult].success
+
+    def release()(using Async): Unit =
+      reqCh.send(ReqMessage.Release)
+      assertEquals(resCh.read().right.get, ResMessage.Done)
+
+    def complete(data: Int)(using Async) =
+      reqCh.send(ReqMessage.Complete(data))
+      assertEquals(resCh.read().right.get, ResMessage.Done)
+
+    def completeNow(data: Int)(using Async) =
+      if lockAndWait() then
+        complete(data)
+        true
+      else false
+
+    def quit()(using Async) =
+      reqCh.send(ReqMessage.Quit)
+      f.await
+
+    val f = Future:
+      var loop = true
+      while loop && !Async.current.group.isCancelled do
+        // on scnative, suspending and changing the carrier thread currently kills lock monitors
+        reqCh.readSource.poll().map(_.right.get).foreach {
+          case ReqMessage.Lock =>
+            resCh.sendImmediately(ResMessage.LockResult(l.acquireLock()))
+          case ReqMessage.Release =>
+            l.releaseLock()
+            resCh.sendImmediately(ResMessage.Done)
+          case ReqMessage.Complete(data) =>
+            l.complete(data, s)
+            resCh.sendImmediately(ResMessage.Done)
+          case ReqMessage.Quit => loop = false
+          case _               => ??? // does not happen
+        }
+    f.onComplete(Listener { (res, _) =>
+      res.failed.foreach: err =>
+        println("Async locker failed with:")
+        err.printStackTrace()
+      reqCh.close()
+      resCh.close()
+    }) // cancels waiting sends/reads

--- a/shared/src/test/scala/ResourceBehavior.scala
+++ b/shared/src/test/scala/ResourceBehavior.scala
@@ -1,0 +1,129 @@
+import gears.async.Async
+import gears.async.AsyncOperations.sleep
+import gears.async.Future
+import gears.async.Future.Promise
+import gears.async.Listener
+import gears.async.Resource
+import gears.async.SyncChannel
+import gears.async.default.given
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Success
+
+import concurrent.duration.DurationInt
+
+class ResourceBehavior extends munit.FunSuite {
+
+  def use(container: Container) =
+    Async.blocking:
+      container.assertInitial()
+      container.res.use(_ => container.waitAcquired())
+      container.waitReleased()
+
+  def allocated(container: Container) =
+    Async.blocking:
+      container.assertInitial()
+      val res = container.res.allocated
+      try container.waitAcquired()
+      finally res._2
+      container.waitReleased()
+
+  def mappedUse(container: Container) =
+    Async.blocking:
+      val res = container.res.map: _ =>
+        container.waitAcquired()
+        "a"
+      container.assertInitial()
+      res.use: str =>
+        assertEquals(str, "a")
+        container.waitAcquired()
+      container.waitReleased()
+
+  def mappedAllocated(container: Container) =
+    Async.blocking:
+      val res = container.res.map: _ =>
+        container.waitAcquired()
+        "a"
+      container.assertInitial()
+
+      val ress = res.allocated
+      try
+        assertEquals(ress._1, "a")
+        container.waitAcquired()
+      finally ress._2
+      container.waitReleased()
+
+  for
+    (implName, impl) <- Seq(("apply", () => ResContainer()), ("Future", () => AsyncResContainer()))
+    (testName, testCase) <- Seq(
+      ("use", use),
+      ("allocated", allocated),
+      ("mappedUse", mappedUse),
+      ("mappedAllocated", mappedAllocated)
+    )
+  do test(s"$implName - $testName")(testCase(impl()))
+
+  test("leak future") {
+    Async.blocking:
+      val container = AsyncResContainer()
+      val res = Async.group:
+        container.res.allocated
+      container.waitAcquired()
+      res._2
+      container.waitReleased()
+  }
+
+  abstract class Container:
+    var acq = Promise[Unit]()
+    var rel = Promise[Unit]()
+
+    def assertInitial() =
+      assert(acq.poll().isEmpty)
+      assert(rel.poll().isEmpty)
+
+    def waitAcquired()(using Async) =
+      acq.await
+      assert(rel.poll().isEmpty)
+
+    def assertAcquiredNow() =
+      assert(acq.poll().isDefined)
+      assert(rel.poll().isEmpty)
+
+    def setAcquired() = acq.complete(Success(()))
+    def setReleased() = rel.complete(Success(()))
+
+    def waitReleased()(using Async) =
+      acq.await
+      rel.await
+
+    def res: Resource[Unit]
+  end Container
+
+  class ResContainer extends Container:
+    // this should be synchronous
+    override def waitAcquired()(using Async): Unit = assertAcquiredNow()
+    override def waitReleased()(using Async): Unit =
+      assert(acq.poll().isDefined)
+      assert(rel.poll().isDefined)
+
+    val res = Resource(
+      { assertInitial(); setAcquired() },
+      _ => { assertAcquiredNow(); setReleased() }
+    )
+
+  class AsyncResContainer extends Container:
+    val ch = SyncChannel[Unit]()
+
+    override def waitAcquired()(using Async): Unit = ch.read().right.get
+
+    val res = Resource.spawning(Future {
+      assertInitial()
+      setAcquired()
+      while true do ch.send(())
+    }.onComplete(Listener.acceptingListener { (tryy, _) =>
+      assert(tryy.isFailure)
+      assertAcquiredNow()
+      setReleased()
+    }))
+
+}

--- a/shared/src/test/scala/SemaphoreBehavior.scala
+++ b/shared/src/test/scala/SemaphoreBehavior.scala
@@ -1,0 +1,67 @@
+import gears.async.Async
+import gears.async.AsyncOperations.sleep
+import gears.async.Future
+import gears.async.Semaphore
+import gears.async.default.given
+import gears.async.withTimeoutOption
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import concurrent.duration.DurationInt
+
+class SemaphoreBehavior extends munit.FunSuite {
+
+  test("single threaded semaphore") {
+    Async.blocking:
+      val sem = Semaphore(2)
+      sem.acquire().release()
+      sem.acquire()
+      sem.acquire()
+  }
+
+  test("single threaded semaphore blocked") {
+    Async.blocking:
+      val sem = Semaphore(2)
+      val guard = sem.acquire()
+      sem.acquire()
+      val res = withTimeoutOption(100.millis)(sem.acquire())
+      assertEquals(res, None)
+      guard.release()
+      sem.acquire()
+  }
+
+  test("binary semaphore") {
+    Async.blocking:
+      val sem = Semaphore(1)
+      var count = 0
+
+      Seq
+        .fill(100)(Future {
+          for i <- 0 until 1_000 do
+            scala.util.Using(sem.acquire()): _ =>
+              count += 1
+        })
+        .awaitAll
+      assertEquals(count, 100_000)
+  }
+
+  test("no release high-numbered semaphore") {
+    val futs = Async.blocking:
+      val sem = Semaphore(100)
+      val count = AtomicInteger()
+
+      val futs = Seq.fill(1_000)(Future {
+        sem.acquire()
+        count.incrementAndGet()
+      })
+
+      while count.get() < 100 do Thread.`yield`()
+      sleep(100)
+      assertEquals(count.get(), 100)
+      futs
+    val (succ, fail) = futs.partition(f => f.poll().get.isSuccess)
+    assertEquals(succ.size, 100)
+    assertEquals(fail.size, 900)
+  }
+
+}


### PR DESCRIPTION
This PR contains primitives for synchronization and concurrency management:
 - `Resource` to wrap allocation/cleanup of (currently mostly computation) resources in different layers of safety
 - `Semaphore`, because it's useful
Additionally, the specification of `Async.await` in light of locking Sources, that care about there result being used (like Semaphores which the consumer might want to reset on cancellation), was clarified and implemented. Now, cancellation will be ignored if it happens after a listener lock acquire that leads to completion. Still, cancellation can be requested synchronously without waiting.