### PR TITLE
Add setup-sbt to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         distribution: temurin
         java-version: 21
+    - uses: sbt/setup-sbt@v1
     - name: Test Formatting
       run: sbt scalafmtCheckAll
   test-jvm:
@@ -35,6 +36,7 @@ jobs:
       with:
         distribution: temurin
         java-version: 21
+    - uses: sbt/setup-sbt@v1
     - name: Test
       run: sbt rootJVM/test
   test-native:
@@ -51,6 +53,7 @@ jobs:
       with:
         distribution: temurin
         java-version: 21
+    - uses: sbt/setup-sbt@v1
     - name: Install scala-native dependencies
       run: sudo apt-get install clang libstdc++-12-dev libgc-dev
     - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
           distribution: temurin
           java-version: 21
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
+      - uses: sbt/setup-sbt@v1
       - name: Build docs
         run: |
           sbt "rootJVM/doc"


### PR DESCRIPTION
From [`setup-sbt`](https://github.com/sbt/setup-sbt) README:

> The situation changed again in December 2024 when GitHub dropped sbt from ubuntu-latest. So now this same action is needed for Ubuntu-based builds, too.
