### PR TITLE
Support Scala.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,23 @@ jobs:
       run: sbt rootNative/test
     - name: Stress Test with Lower Memory
       run: env GC_MAXIMUM_HEAP_SIZE=140M sbt 'rootNative/testOnly StressTest'
+  test-js:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: coursier/cache-action@v6
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 21
+    - uses: actions/setup-node@v4
+      with:
+          node-version: '>=23'
+    - uses: sbt/setup-sbt@v1
+    - name: Test
+      run: sbt rootJS/test

--- a/build.sbt
+++ b/build.sbt
@@ -59,13 +59,10 @@ lazy val root =
             .Config()
             .withArgs(
               List(
-                "--stack_size=4096",
-                "--stack-trace-limit=50",
                 "--experimental-wasm-exnref", // always required
                 "--experimental-wasm-jspi", // required for js.async/js.await
                 "--experimental-wasm-imported-strings", // optional (good for performance)
                 "--turboshaft-wasm" // optional, but significantly increases stability
-
               )
             )
           new NodeJSEnv(config)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import org.scalajs.jsenv.nodejs._
+import org.scalajs.linker.interface.ESVersion
 import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
 import scalanative.build._
 
@@ -39,15 +40,17 @@ lazy val root =
       Seq(
         nativeConfig ~= { c =>
           c.withMultithreading(true)
+            .withOptimize(true)
         }
       )
     )
     .jsSettings(
       Seq(
-        scalaVersion := "3.7.1-RC1-bin-20250417-05b102a-NIGHTLY",
+        scalaVersion := "3.7.1-RC1-bin-20250425-fb6cc9b-NIGHTLY",
         // Emit ES modules with the Wasm backend
         scalaJSLinkerConfig := {
           scalaJSLinkerConfig.value
+            .withESFeatures(_.withESVersion(ESVersion.ES2017)) // enable async/await
             .withExperimentalUseWebAssembly(true) // use the Wasm backend
             .withModuleKind(ModuleKind.ESModule) // required by the Wasm backend
         },
@@ -57,13 +60,90 @@ lazy val root =
             .Config()
             .withArgs(
               List(
+                "--stack_size=4096",
+                "--stack-trace-limit=50",
                 "--experimental-wasm-exnref", // always required
                 "--experimental-wasm-jspi", // required for js.async/js.await
                 "--experimental-wasm-imported-strings", // optional (good for performance)
                 "--turboshaft-wasm" // optional, but significantly increases stability
+
               )
             )
           new NodeJSEnv(config)
+        },
+
+        // Patch the sjsir of JSPI to introduce primitives by hand
+        Compile / compile := {
+          val analysis = (Compile / compile).value
+
+          val s = streams.value
+          val classDir = (Compile / classDirectory).value
+          val jspiIRFile = classDir / "gears/async/js/JSPI$.sjsir"
+          patchJSPIIR(jspiIRFile, s)
+
+          analysis
         }
       )
     )
+
+def patchJSPIIR(jspiIRFile: File, streams: TaskStreams): Unit = {
+  import org.scalajs.ir.Names._
+  import org.scalajs.ir.Trees._
+  import org.scalajs.ir.Types._
+  import org.scalajs.ir.WellKnownNames._
+
+  val content = java.nio.ByteBuffer.wrap(java.nio.file.Files.readAllBytes(jspiIRFile.toPath()))
+  val classDef = org.scalajs.ir.Serializers.deserialize(content)
+
+  val newMethods = classDef.methods.mapConserve { m =>
+    (m.methodName.simpleName.nameString, m.body) match {
+      case ("async", Some(UnaryOp(UnaryOp.Throw, _))) =>
+        implicit val pos = m.pos
+        val closure = Closure(
+          ClosureFlags.arrow.withAsync(true),
+          m.args,
+          Nil,
+          None,
+          AnyType,
+          Apply(ApplyFlags.empty, m.args.head.ref, MethodIdent(MethodName("apply", Nil, ObjectRef)), Nil)(AnyType),
+          m.args.map(_.ref)
+        )
+        val newBody = Some(JSFunctionApply(closure, Nil))
+        m.copy(body = newBody)(m.optimizerHints, m.version)(m.pos)
+
+      case ("await", Some(UnaryOp(UnaryOp.Throw, _))) =>
+        implicit val pos = m.pos
+        val newBody = Some(JSAwait(m.args.head.ref))
+        m.copy(body = newBody)(m.optimizerHints, m.version)(m.pos)
+
+      case _ =>
+        m
+    }
+  }
+
+  if (newMethods ne classDef.methods) {
+    streams.log.info("Patching JSPI$.sjsir")
+    val newClassDef = {
+      import classDef._
+      ClassDef(
+        name,
+        originalName,
+        kind,
+        jsClassCaptures,
+        superClass,
+        interfaces,
+        jsSuperClass,
+        jsNativeLoadSpec,
+        fields,
+        newMethods,
+        jsConstructor,
+        jsMethodProps,
+        jsNativeMembers,
+        topLevelExportDefs
+      )(optimizerHints)(pos)
+    }
+    val baos = new java.io.ByteArrayOutputStream()
+    org.scalajs.ir.Serializers.serialize(baos, newClassDef)
+    java.nio.file.Files.write(jspiIRFile.toPath(), baos.toByteArray())
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ lazy val root =
       Seq(
         nativeConfig ~= { c =>
           c.withMultithreading(true)
-            .withOptimize(true)
         }
       )
     )

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1715865404,
-        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715787315,
-        "narHash": "sha256-cYApT0NXJfqBkKcci7D9Kr4CBYZKOQKDYA23q8XNuWg=",
+        "lastModified": 1745234285,
+        "narHash": "sha256-GfpyMzxwkfgRVN0cTGQSkTC0OHhEkv3Jf6Tcjm//qZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "33d1e753c82ffc557b4a585c77de43d4c922ebb5",
+        "rev": "c11863f1e964833214b767f4a369c6e6a7aba141",
         "type": "github"
       },
       "original": {
@@ -36,14 +36,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1714640452,
-        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,35 +6,52 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = inputs@{ flake-parts, ... }:
+  outputs =
+    inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [ ];
-      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
-      perSystem = { config, self', inputs', pkgs, system, ... }: {
-        # Per-system attributes can be defined here. The self' and inputs'
-        # module parameters provide easy access to attributes of the same
-        # system.
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            jdk21
-            # Scala deps
-            (sbt.override { jre = jdk21; })
-            # Scala Native deps
-            llvm
-            clang
-            boehmgc
-            libunwind
-            zlib
-            # Dev deps
-            metals
-            scalafix
-            scalafmt
-          ];
-          shellHook = ''
-            export LLVM_BIN=${pkgs.clang}/bin
-          '';
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      perSystem =
+        {
+          config,
+          self',
+          inputs',
+          pkgs,
+          system,
+          ...
+        }:
+        {
+          # Per-system attributes can be defined here. The self' and inputs'
+          # module parameters provide easy access to attributes of the same
+          # system.
+          devShells.default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              jdk21
+              # Scala deps
+              (sbt.override { jre = jdk21; })
+              # Scala Native deps
+              llvm
+              clang
+              boehmgc
+              libunwind
+              zlib
+              # Scala.js deps
+              nodejs_23
+              # Dev deps
+              metals
+              scalafix
+              scalafmt
+            ];
+            shellHook = ''
+              export LLVM_BIN=${pkgs.clang}/bin
+            '';
+          };
         };
-      };
       flake = {
         # The usual flake attributes can be defined here, including system-
         # agnostic ones like nixosModule and system-enumerating ones, although

--- a/js/src/main/scala/async/AsyncImpl.scala
+++ b/js/src/main/scala/async/AsyncImpl.scala
@@ -1,0 +1,3 @@
+package gears.async
+
+private[async] abstract class AsyncImpl

--- a/js/src/main/scala/async/JSPI.scala
+++ b/js/src/main/scala/async/JSPI.scala
@@ -1,0 +1,14 @@
+package gears.async.js
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.*
+
+private[async] object JSPI:
+  @inline
+  def async[A](computation: => A): js.Promise[A] =
+    throw new Error("async stub")
+
+  @inline
+  def await[A](p: js.Promise[A]): A =
+    throw new Error("await stub")
+end JSPI

--- a/js/src/main/scala/async/JSPI.scala
+++ b/js/src/main/scala/async/JSPI.scala
@@ -3,6 +3,10 @@ package gears.async.js
 import scala.scalajs.js
 import scala.scalajs.js.annotation.*
 
+/** A stub implementation of the [[js.async]]/[[js.await]] functions, which are not yet available natively on Scala 3.
+  *
+  * See how the stubs are compiled in `build.sbt`.
+  */
 private[async] object JSPI:
   @inline
   def async[A](computation: => A): js.Promise[A] =

--- a/js/src/main/scala/async/ListenerImpl.scala
+++ b/js/src/main/scala/async/ListenerImpl.scala
@@ -11,7 +11,7 @@ import scala.scalajs.js
 private[async] trait NumberedLockImpl:
   protected val numberedLock = new Lock:
     var locked = false
-    val queue = scala.collection.mutable.Queue[() => Unit]()
+    val queue = scala.collection.mutable.Queue[(Unit) => Any]()
 
     override def newCondition(): Condition =
       throw NotImplementedError()
@@ -28,13 +28,13 @@ private[async] trait NumberedLockImpl:
     override def lock(): Unit =
       while !tryLock() do
         val promise = js.Promise[Unit]: (resolve, _) =>
-          queue += (() => resolve(()))
+          queue += resolve
         JSPI.await(promise)
 
     override def unlock(): Unit =
       assert(locked, "unlocking an unlocked lock")
       locked = false
-      if !queue.isEmpty then queue.dequeue()()
+      if !queue.isEmpty then queue.dequeue()(())
 
     override def lockInterruptibly(): Unit =
       throw NotImplementedError()

--- a/js/src/main/scala/async/ListenerImpl.scala
+++ b/js/src/main/scala/async/ListenerImpl.scala
@@ -1,0 +1,40 @@
+package gears.async
+
+import gears.async.js.JSPI
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.*
+import scala.concurrent.duration.*
+import scala.scalajs.js
+
+/** Assumes top-level await, probably will crash real hard. */
+private[async] trait NumberedLockImpl:
+  protected val numberedLock = new Lock:
+    var locked = false
+    val queue = scala.collection.mutable.Queue[() => Unit]()
+
+    override def newCondition(): Condition =
+      throw NotImplementedError()
+
+    override def tryLock(): Boolean =
+      if locked then false
+      else
+        locked = true
+        true
+
+    override def tryLock(time: Long, unit: TimeUnit): Boolean =
+      throw NotImplementedError()
+
+    override def lock(): Unit =
+      while !tryLock() do
+        val promise = js.Promise[Unit]: (resolve, _) =>
+          queue += (() => resolve(()))
+        JSPI.await(promise)
+
+    override def unlock(): Unit =
+      assert(locked, "unlocking an unlocked lock")
+      locked = false
+      if !queue.isEmpty then queue.dequeue()()
+
+    override def lockInterruptibly(): Unit =
+      throw NotImplementedError()

--- a/js/src/main/scala/async/WasmJSPISuspend.scala
+++ b/js/src/main/scala/async/WasmJSPISuspend.scala
@@ -1,0 +1,91 @@
+package gears.async.js
+
+import gears.async.*
+
+import scala.compiletime.uninitialized
+import scala.scalajs.js
+import scala.scalajs.js.wasm.JSPI.allowOrphanJSAwait
+
+opaque type AsyncToken = Unit
+
+/** Capability-safe wrapper around [[js.async]]. */
+private[async] inline def async[T](body: AsyncToken ?=> T): js.Promise[T] = js.async(body(using ()))
+
+/** Note that this assumes that the root context is **already** under `js.async`. */
+trait WasmJSPISuspend(using AsyncToken) extends SuspendSupport:
+  protected class WasmLabel[T]():
+    var (promise, resolve) = mkPromise[T]
+
+    def reset() =
+      var (p, q) = mkPromise[T]
+      promise = p
+      resolve = q
+
+  inline def mkPromise[T]: (js.Promise[T], T => Any) =
+    var resolve: (T => Any) | Null = null
+    val promise = js.Promise[T]((res, rej) => resolve = res)
+    (promise, resolve)
+
+  opaque type Label[T] = WasmLabel[T]
+
+  def boundary[T](body: Label[T] ?=> T): T =
+    val label = WasmLabel[T]()
+    js.async:
+      label.resolve(body(using label))
+    js.await(label.promise)
+
+  protected class WasmSuspension[-T, +R](label: Label[R], resolve: T => Any) extends gears.async.Suspension[T, R]:
+    def resume(arg: T): R =
+      label.reset()
+      resolve(arg)
+      js.await(label.promise)
+
+  opaque type Suspension[-T, +R] <: gears.async.Suspension[T, R] = WasmSuspension[T, R]
+
+  /** Should return immediately if resume is called from within body */
+  def suspend[T, R](body: Suspension[T, R] => R)(using label: Label[R]): T =
+    val (suspPromise, suspResolve) = mkPromise[T]
+    val suspend = WasmSuspension[T, R](label, suspResolve)
+    label.resolve(body(suspend))
+    js.await(suspPromise)
+
+object JsAsyncOperations extends AsyncOperations:
+  def sleep(millis: Long)(using Async) =
+    import scala.concurrent.duration.*
+    Future
+      .withResolver: resolver =>
+        val handle = js.timers.setTimeout(millis.millis)(resolver.resolve(()))
+        resolver.onCancel(() => js.timers.clearTimeout(handle))
+      .await
+
+object JsAsyncScheduler extends Scheduler:
+  def execute(body: Runnable) = js.async(body)
+  def schedule(delay: scala.concurrent.duration.FiniteDuration, body: Runnable) =
+    new Cancellable:
+      val handle = js.timers.setTimeout(delay)(body.run())
+      def cancel() =
+        js.timers.clearTimeout(handle)
+
+final class WasmAsyncSupport(using AsyncToken) extends AsyncSupport with WasmJSPISuspend:
+  type Scheduler = JsAsyncScheduler.type
+
+private[async] class JsAsync(val group: CompletionGroup)(using support: WasmAsyncSupport, sched: JsAsyncScheduler.type)
+    extends Async(using support, sched):
+  override def await[T](src: Async.Source[T]) =
+    src
+      .poll()
+      .getOrElse:
+        js.await:
+          js.Promise: (resolve, _) =>
+            src.onComplete:
+              Listener: (item, _) =>
+                resolve(item)
+  def withGroup(group: CompletionGroup) = JsAsync(group)
+
+object JsAsyncFromSync extends Async.FromSync:
+  type Output[+T] = js.Promise[T]
+  def apply[T](body: Async ?=> T): Output[T] =
+    async:
+      given WasmAsyncSupport = WasmAsyncSupport()
+      given JsAsyncScheduler.type = JsAsyncScheduler
+      body(using JsAsync(CompletionGroup.Unlinked))

--- a/js/src/main/scala/async/WasmJSPISuspend.scala
+++ b/js/src/main/scala/async/WasmJSPISuspend.scala
@@ -6,6 +6,7 @@ import scala.compiletime.uninitialized
 import scala.scalajs.js
 import scala.scalajs.js.wasm.JSPI.allowOrphanJSAwait
 
+/** An opaque, compile-time token to signal that we are under a [[js.async]] scope. */
 opaque type AsyncToken = Unit
 
 object AsyncToken:
@@ -15,8 +16,18 @@ object AsyncToken:
 /** Capability-safe wrapper around [[JSPI.async]]. */
 private[async] inline def async[T](body: AsyncToken ?=> T): js.Promise[T] = JSPI.async(body(using ()))
 
-/** Note that this assumes that the root context is **already** under `JSPI.async`. */
+/** An implementation of [[SuspendSupport]] using JSPI async/await under WebAssembly.
+  * @note
+  *   this assumes that the root context is **already** under `JSPI.async`.
+  */
 trait WasmJSPISuspend(using AsyncToken) extends SuspendSupport:
+  /** The label stores a Promise that should be resolved every time the context is suspended or is completed. Since
+    * Promises are one-time resolvables, every resumption will "reset" the label, giving it a new Promise (see
+    * [[WasmLabel.reset]]).
+    *
+    * Due to the promise possibly changing over time, within [[boundary]], we have to dynamically resolve the reference
+    * _after_ running the `body`.
+    */
   protected class WasmLabel[T]():
     var (promise, resolve) = mkPromise[T]
 
@@ -25,19 +36,11 @@ trait WasmJSPISuspend(using AsyncToken) extends SuspendSupport:
       promise = p
       resolve = q
 
+  /** Creates a new [[js.Promise]] and returns both the Promise and its `resolve` function. */
   inline def mkPromise[T]: (js.Promise[T], T => Any) =
     var resolve: (T => Any) | Null = null
     val promise = js.Promise[T]((res, rej) => resolve = res)
     (promise, resolve)
-
-  opaque type Label[T] = WasmLabel[T]
-
-  override def boundary[T](body: Label[T] ?=> T): T =
-    val label = WasmLabel[T]()
-    JSPI.async:
-      val r = body(using label)
-      label.resolve(r)
-    JSPI.await(label.promise)
 
   protected class WasmSuspension[-T, +R](label: Label[R], resolve: T => Any) extends gears.async.Suspension[T, R]:
     def resume(arg: T): R =
@@ -45,19 +48,41 @@ trait WasmJSPISuspend(using AsyncToken) extends SuspendSupport:
       resolve(arg)
       JSPI.await(label.promise)
 
+  // Implementation of the [[SuspendSupport]] interface.
+
+  opaque type Label[T] = WasmLabel[T]
+
   opaque type Suspension[-T, +R] <: gears.async.Suspension[T, R] = WasmSuspension[T, R]
 
-  /** Should return immediately if resume is called from within body */
+  override def boundary[T](body: Label[T] ?=> T): T =
+    val label = WasmLabel[T]()
+    JSPI.async:
+      val r = body(using label)
+      label.resolve(r) // see [[WasmLabel]]
+    JSPI.await(label.promise) // this is fine to resolve immediately, since we only wait for the first return.
+
+  /** Suspends the context by creating a [[js.Promise]] to wait for inside the [[Suspension]] class, that would be
+    * resolved once resumed.
+    * @note
+    *   Should return immediately if resume is called from within body
+    */
   override def suspend[T, R](body: Suspension[T, R] => R)(using label: Label[R]): T =
     val (suspPromise, suspResolve) = mkPromise[T]
     val suspend = WasmSuspension[T, R](label, suspResolve)
     label.resolve(body(suspend))
     JSPI.await(suspPromise)
+end WasmJSPISuspend
 
+/** Overrides [[AsyncOperations]] with JavaScript-specific operations. */
 object JsAsyncOperations extends AsyncOperations:
   override def `yield`()(using Async) =
     sleep(1)
 
+/** An implementaion of [[Scheduler]] that assumes a single-threaded, event-loop driven JavaScript context.
+  *
+  * In this context, `execute` will always immediately run (while under a [[js.async]] scope, so that suspension is
+  * possible), while `schedule`d computations only run when another computation has yielded.
+  */
 object JsAsyncScheduler extends Scheduler:
   def execute(body: Runnable) = JSPI.async(body.run())
   def schedule(delay: scala.concurrent.duration.FiniteDuration, body: Runnable) =
@@ -66,22 +91,31 @@ object JsAsyncScheduler extends Scheduler:
       def cancel() =
         js.timers.clearTimeout(handle)
 
+/** An implementation of [[AsyncSupport]] where we assume a JSPI-enabled WebAssembly environment under a
+  * single-threaded, event-loop driven JavaScript scheduler (as assumed by [[JsAsyncScheduler]]).
+  */
 final class WasmAsyncSupport(using AsyncToken) extends AsyncSupport with WasmJSPISuspend:
   type Scheduler = JsAsyncScheduler.type
 
+/** A special root-level implementation of the [[Async]] context, that uses JSPI async/await on top-level to wait for
+  * futures.
+  */
 private[async] class JsAsync(val group: CompletionGroup)(using support: WasmAsyncSupport, sched: JsAsyncScheduler.type)
     extends Async(using support, sched):
   override def await[T](src: Async.Source[T]) =
     src
       .poll()
       .getOrElse:
-        JSPI.await:
+        JSPI.await: // TODO: can we make this more efficient?
           js.Promise: (resolve, _) =>
             src.onComplete:
               Listener: (item, _) =>
                 resolve(item)
   def withGroup(group: CompletionGroup) = JsAsync(group)
 
+/** An implementation of [[Async.FromSync]] that returns a [[scala.concurrent.Future]] for a top-level
+  * [[Async.blocking]] computation.
+  */
 object JsAsyncFromSync extends Async.FromSync:
   type Output[+T] = scala.concurrent.Future[T]
   def apply[T](body: Async ?=> T): Output[T] =
@@ -91,7 +125,7 @@ object JsAsyncFromSync extends Async.FromSync:
       Async.group(body)(using JsAsync(CompletionGroup.Unlinked))
     .toFuture
 
-/** Alternative [[Async.FromAsync]] implementation. Assumes** that we are under an `async` scope.
+/** Alternative [[Async.FromAsync]] implementation. **Assumes** that we are under an `async` scope.
   */
 object UnsafeJsAsyncFromSync extends Async.FromSync:
   type Output[+T] = T

--- a/js/src/main/scala/async/default.scala
+++ b/js/src/main/scala/async/default.scala
@@ -1,0 +1,6 @@
+package gears.async.default
+
+import gears.async.js
+
+given js.JsAsyncFromSync.type = js.JsAsyncFromSync
+given js.JsAsyncOperations.type = js.JsAsyncOperations

--- a/js/src/test/scala/SingleThreadedSupport.scala
+++ b/js/src/test/scala/SingleThreadedSupport.scala
@@ -1,0 +1,3 @@
+import gears.async.*
+
+val SingleThreadedSupport = js.UnsafeJsAsyncFromSync

--- a/js/src/test/scala/TestListenerImpl.scala
+++ b/js/src/test/scala/TestListenerImpl.scala
@@ -1,0 +1,7 @@
+import gears.async.*
+import gears.async.{js => gearsJS}
+
+import scalajs.js
+
+trait TestListenerImpl:
+  given Async.FromSync.Blocking = gearsJS.UnsafeJsAsyncFromSync

--- a/jvm/src/main/scala/async/AsyncImpl.scala
+++ b/jvm/src/main/scala/async/AsyncImpl.scala
@@ -2,4 +2,5 @@ package gears.async
 
 private[async] abstract class AsyncImpl:
   import Async.FromSync
-  given blockingImpl: FromSync.BlockingWithLocks.type = FromSync.BlockingWithLocks
+  given blockingImpl(using support: AsyncSupport, scheduler: support.Scheduler): FromSync.BlockingWithLocks =
+    FromSync.BlockingWithLocks()

--- a/jvm/src/main/scala/async/AsyncImpl.scala
+++ b/jvm/src/main/scala/async/AsyncImpl.scala
@@ -1,0 +1,5 @@
+package gears.async
+
+private[async] abstract class AsyncImpl:
+  import Async.FromSync
+  given blockingImpl: FromSync.BlockingWithLocks.type = FromSync.BlockingWithLocks

--- a/jvm/src/main/scala/async/JvmAsyncOperations.scala
+++ b/jvm/src/main/scala/async/JvmAsyncOperations.scala
@@ -4,6 +4,8 @@ object JvmAsyncOperations extends AsyncOperations:
   override def sleep(millis: Long)(using Async): Unit =
     jvmInterruptible(Thread.sleep(millis))
 
+  override def `yield`()(using Async): Unit = Thread.`yield`()
+
   /** Runs `fn` in a [[cancellationScope]] where it will be interrupted (as a Java thread) upon cancellation.
     *
     * Note that `fn` will need to handle both [[java.util.concurrent.CancellationException]] (when performing Gears

--- a/jvm/src/main/scala/async/ListenerImpl.scala
+++ b/jvm/src/main/scala/async/ListenerImpl.scala
@@ -1,0 +1,6 @@
+package gears.async
+
+import java.util.concurrent.locks.*
+
+private[async] trait NumberedLockImpl:
+  protected val numberedLock: Lock = ReentrantLock()

--- a/jvm/src/test/scala/SingleThreadedSupport.scala
+++ b/jvm/src/test/scala/SingleThreadedSupport.scala
@@ -1,0 +1,4 @@
+import gears.async.*
+import gears.async.default.given
+
+val SingleThreadedSupport = summon[Async.FromSync.BlockingWithLocks]

--- a/jvm/src/test/scala/TestListenerImpl.scala
+++ b/jvm/src/test/scala/TestListenerImpl.scala
@@ -1,0 +1,5 @@
+import gears.async.*
+import gears.async.default.given
+
+trait TestListenerImpl:
+  given Async.FromSync.Blocking = Async.FromSync.BlockingWithLocks()

--- a/native/src/main/scala/async/AsyncImpl.scala
+++ b/native/src/main/scala/async/AsyncImpl.scala
@@ -2,4 +2,5 @@ package gears.async
 
 private[async] abstract class AsyncImpl:
   import Async.FromSync
-  given blockingImpl: FromSync.BlockingWithLocks.type = FromSync.BlockingWithLocks
+  given blockingImpl(using support: AsyncSupport, scheduler: support.Scheduler): FromSync.BlockingWithLocks =
+    FromSync.BlockingWithLocks()

--- a/native/src/main/scala/async/AsyncImpl.scala
+++ b/native/src/main/scala/async/AsyncImpl.scala
@@ -1,0 +1,5 @@
+package gears.async
+
+private[async] abstract class AsyncImpl:
+  import Async.FromSync
+  given blockingImpl: FromSync.BlockingWithLocks.type = FromSync.BlockingWithLocks

--- a/native/src/main/scala/async/ForkJoinSupport.scala
+++ b/native/src/main/scala/async/ForkJoinSupport.scala
@@ -83,15 +83,6 @@ class SuspendExecutorWithSleep(exec: ExecutionContext)
     with AsyncOperations
     with NativeSuspend {
   type Scheduler = this.type
-  override def sleep(millis: Long)(using Async): Unit =
-    Future
-      .withResolver[Unit]: resolver =>
-        val cancellable = schedule(millis.millis, () => resolver.resolve(()))
-        resolver.onCancel: () =>
-          cancellable.cancel()
-          resolver.rejectAsCancelled()
-      .link()
-      .await
 }
 
 class ForkJoinSupport extends SuspendExecutorWithSleep(new ForkJoinPool())

--- a/native/src/main/scala/async/ListenerImpl.scala
+++ b/native/src/main/scala/async/ListenerImpl.scala
@@ -1,0 +1,6 @@
+package gears.async
+
+import java.util.concurrent.locks.*
+
+private[async] trait NumberedLockImpl:
+  protected val numberedLock: Lock = ReentrantLock()

--- a/native/src/test/scala/SingleThreadedSupport.scala
+++ b/native/src/test/scala/SingleThreadedSupport.scala
@@ -1,0 +1,9 @@
+import gears.async.*
+import gears.async.native.SuspendExecutorWithSleep
+
+import java.util.concurrent.ForkJoinPool
+import scala.concurrent.JavaConversions.asExecutionContext
+
+val SingleThreadedSupport =
+  val t = SuspendExecutorWithSleep(new ForkJoinPool(1))
+  Async.FromSync.BlockingWithLocks(using t, t)

--- a/native/src/test/scala/TestListenerImpl.scala
+++ b/native/src/test/scala/TestListenerImpl.scala
@@ -1,0 +1,5 @@
+import gears.async.*
+import gears.async.default.given
+
+trait TestListenerImpl:
+  given Async.FromSync.Blocking = Async.FromSync.BlockingWithLocks()

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.7")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.19.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")

--- a/shared/src/main/scala/async/Async.scala
+++ b/shared/src/main/scala/async/Async.scala
@@ -30,7 +30,7 @@ import scala.util.boundary
   * @see
   *   [[Async$.group Async.group]] and [[Future$.apply Future.apply]] for [[Async]]-subscoping operations.
   */
-trait Async(using val support: AsyncSupport, val scheduler: support.Scheduler):
+trait Async private[async] (using val support: AsyncSupport, val scheduler: support.Scheduler):
   /** Waits for completion of source `src` and returns the result. Suspends the computation.
     *
     * @see
@@ -86,6 +86,8 @@ object Async extends AsyncImpl:
     private[async] def apply[T](body: Async ?=> T): Output[T]
 
   object FromSync:
+    /** A [[FromSync]] implementation that blocks the current runtime. */
+    type Blocking = FromSync { type Output[+T] = T }
 
     /** Implements [[FromSync]] by directly blocking the current thread. */
     class BlockingWithLocks(using support: AsyncSupport, scheduler: support.Scheduler) extends FromSync:

--- a/shared/src/main/scala/async/AsyncOperations.scala
+++ b/shared/src/main/scala/async/AsyncOperations.scala
@@ -11,8 +11,26 @@ import scala.concurrent.duration.FiniteDuration
   *   [[Scheduler]] for the definition of the scheduler itself.
   */
 trait AsyncOperations:
+  import scala.concurrent.duration.*
+
   /** Suspends the current [[Async]] context for at least `millis` milliseconds. */
-  def sleep(millis: Long)(using Async): Unit
+  def sleep(millis: Long)(using async: Async): Unit =
+    Future
+      .withResolver[Unit]: resolver =>
+        val cancellable = async.scheduler.schedule(millis.millis, () => resolver.resolve(()))
+        resolver.onCancel: () =>
+          cancellable.cancel()
+          resolver.rejectAsCancelled()
+      .link()
+      .await
+
+  /** Yields the current [[Async]] context, possibly allowing other computations to run. */
+  def `yield`()(using async: Async) =
+    Future
+      .withResolver[Unit]: resolver =>
+        async.scheduler.execute(() => resolver.resolve(()))
+      .link()
+      .await
 
 object AsyncOperations:
   /** Suspends the current [[Async]] context for at least `millis` milliseconds.
@@ -28,6 +46,10 @@ object AsyncOperations:
     */
   inline def sleep(duration: FiniteDuration)(using AsyncOperations, Async): Unit =
     sleep(duration.toMillis)
+
+  /** Yields the current [[Async]] context, possibly allowing other computations to run. */
+  inline def `yield`()(using AsyncOperations, Async) =
+    summon[AsyncOperations].`yield`()
 
 /** Runs `op` with a timeout. When the timeout occurs, `op` is cancelled through the given [[Async]] context, and
   * [[java.util.concurrent.TimeoutException]] is thrown.

--- a/shared/src/main/scala/async/Cancellable.scala
+++ b/shared/src/main/scala/async/Cancellable.scala
@@ -3,7 +3,7 @@ package gears.async
 /** A trait for cancellable entities that can be grouped. */
 trait Cancellable:
 
-  private var group: CompletionGroup = CompletionGroup.Unlinked
+  private var group: CompletionGroup = scala.compiletime.uninitialized
 
   /** Issue a cancel request */
   def cancel(): Unit
@@ -11,7 +11,7 @@ trait Cancellable:
   /** Add this cancellable to the given group after removing it from the previous group in which it was.
     */
   def link(group: CompletionGroup): this.type = synchronized:
-    this.group.drop(this)
+    if this.group != null then this.group.drop(this)
     this.group = group
     this.group.add(this)
     this

--- a/shared/src/main/scala/async/CompletionGroup.scala
+++ b/shared/src/main/scala/async/CompletionGroup.scala
@@ -43,11 +43,10 @@ class CompletionGroup extends Cancellable.Tracking:
   def isCancelled = canceled
 
 object CompletionGroup:
-
   /** A sentinel group of cancellables that are in fact not linked to any real group. `cancel`, `add`, and `drop` do
     * nothing when called on this group.
     */
-  object Unlinked extends CompletionGroup:
+  val Unlinked = new CompletionGroup:
     override def cancel(): Unit = ()
     override def waitCompletion()(using Async): Unit = ()
     override def add(member: Cancellable): Unit = ()

--- a/shared/src/main/scala/async/CompletionGroup.scala
+++ b/shared/src/main/scala/async/CompletionGroup.scala
@@ -46,7 +46,7 @@ object CompletionGroup:
   /** A sentinel group of cancellables that are in fact not linked to any real group. `cancel`, `add`, and `drop` do
     * nothing when called on this group.
     */
-  val Unlinked = new CompletionGroup:
+  object Unlinked extends CompletionGroup:
     override def cancel(): Unit = ()
     override def waitCompletion()(using Async): Unit = ()
     override def add(member: Cancellable): Unit = ()

--- a/shared/src/main/scala/async/Listener.scala
+++ b/shared/src/main/scala/async/Listener.scala
@@ -98,11 +98,10 @@ object Listener:
       case l: ListenerLock => body(l)
 
   /** A helper instance that provides an uniquely numbered mutex. */
-  trait NumberedLock:
+  trait NumberedLock extends NumberedLockImpl:
     import NumberedLock._
 
     protected val number = listenerNumber.getAndIncrement()
-    protected val numberedLock: Lock = ReentrantLock()
 
   object NumberedLock:
     private val listenerNumber = java.util.concurrent.atomic.AtomicLong()

--- a/shared/src/main/scala/async/futures.scala
+++ b/shared/src/main/scala/async/futures.scala
@@ -128,10 +128,7 @@ object Future:
             Listener.ListenerLock,
             Listener.NumberedLock,
             Cancellable:
-        val stateUnused = 0
-        val stateLocked = 1
-        val stateDone = 2
-        val stateCancelled = 3
+        import AwaitListener.*
         var state = stateUnused // 0 -> unused, 1 -> locked, 2 -> done, 3 -> cancelled
         // resumed due to cancellation - only set with lock held immediately before resume
 
@@ -197,6 +194,11 @@ object Future:
 
         inline def cancelled = state == stateCancelled
       end AwaitListener
+      object AwaitListener:
+        inline val stateUnused = 0
+        inline val stateLocked = 1
+        inline val stateDone = 2
+        inline val stateCancelled = 3
 
       /** Await a source first by polling it, and, if that fails, by suspending in a onComplete call.
         */

--- a/shared/src/main/scala/async/futures.scala
+++ b/shared/src/main/scala/async/futures.scala
@@ -129,8 +129,7 @@ object Future:
             Listener.NumberedLock,
             Cancellable:
         import AwaitListener.*
-        var state = stateUnused // 0 -> unused, 1 -> locked, 2 -> done, 3 -> cancelled
-        // resumed due to cancellation - only set with lock held immediately before resume
+        var state: State = stateUnused
 
         // guarded by lock; null = before apply or after resume
         private var sus: ac.support.Suspension[T | Null, Unit] | Null = null
@@ -195,10 +194,11 @@ object Future:
         inline def cancelled = state == stateCancelled
       end AwaitListener
       object AwaitListener:
+        type State = stateUnused.type | stateLocked.type | stateDone.type | stateCancelled.type
         inline val stateUnused = 0
         inline val stateLocked = 1
         inline val stateDone = 2
-        inline val stateCancelled = 3
+        inline val stateCancelled = 3 // resumed due to cancellation - only set with lock held immediately before resume
 
       /** Await a source first by polling it, and, if that fails, by suspending in a onComplete call.
         */

--- a/shared/src/test/scala/AwaitBehavior.scala
+++ b/shared/src/test/scala/AwaitBehavior.scala
@@ -23,7 +23,7 @@ class AwaitBehavior extends munit.FunSuite:
     def res()(using Async) = res0.awaitResult
 
   test("completion after cancellation"):
-    Async.blocking:
+    Async.fromSync:
       val handle = FutHandle()
       handle.cancel()
       assert(!handle.locker.completeNow(1))
@@ -31,7 +31,7 @@ class AwaitBehavior extends munit.FunSuite:
       handle.locker.quit()
 
   test("cancellation of await during completion"):
-    Async.blocking:
+    Async.fromSync:
       val handle = FutHandle()
       assert(handle.locker.lockAndWait())
       println(handle.listener)
@@ -42,7 +42,7 @@ class AwaitBehavior extends munit.FunSuite:
       handle.locker.quit()
 
   test("cancellation of await during lock+release"):
-    Async.blocking:
+    Async.fromSync:
       val handle = FutHandle()
       assert(handle.locker.lockAndWait())
       handle.cancel()
@@ -51,7 +51,7 @@ class AwaitBehavior extends munit.FunSuite:
       handle.locker.quit()
 
   test("cancellation of await with contending lock after release"):
-    Async.blocking:
+    Async.fromSync:
       val handle = FutHandle()
       assert(handle.locker.lockAndWait())
       val fut2 = Future(assert(!handle.listener.acquireLock()))
@@ -101,8 +101,7 @@ class AwaitBehavior extends munit.FunSuite:
     val f = Future:
       // on scnative, suspending and changing the carrier thread currently kills lock monitors
       // so we run the body in a special single-threaded context
-      given SingleThreadedSupport.type = SingleThreadedSupport
-      Async.blocking:
+      Async.blocking(using SingleThreadedSupport):
         var loop = 0
         while loop >= 0 && !Async.current.group.isCancelled do
           if loop == 0 then AsyncOperations.`yield`()

--- a/shared/src/test/scala/AwaitBehavior.scala
+++ b/shared/src/test/scala/AwaitBehavior.scala
@@ -34,8 +34,6 @@ class AwaitBehavior extends munit.FunSuite:
     Async.fromSync:
       val handle = FutHandle()
       assert(handle.locker.lockAndWait())
-      println(handle.listener)
-      println(handle.fut)
       handle.cancel()
       handle.locker.complete(1)
       assertEquals(handle.res(), Success(1))

--- a/shared/src/test/scala/CancellationBehavior.scala
+++ b/shared/src/test/scala/CancellationBehavior.scala
@@ -75,7 +75,7 @@ class CancellationBehavior extends munit.FunSuite:
         Future:
           sleep(400)
           x = 1
-    assertEquals(x, 0)
+      assertEquals(x, 0)
 
   test("link group"):
     val info = Info()

--- a/shared/src/test/scala/CancellationBehavior.scala
+++ b/shared/src/test/scala/CancellationBehavior.scala
@@ -62,7 +62,7 @@ class CancellationBehavior extends munit.FunSuite:
 
   test("no cancel"):
     var x = 0
-    Async.blocking:
+    Async.fromSync:
       Future:
         x = 1
       AsyncOperations.sleep(400)
@@ -70,7 +70,7 @@ class CancellationBehavior extends munit.FunSuite:
 
   test("group cancel"):
     var x = 0
-    Async.blocking:
+    Async.fromSync:
       Async.group:
         Future:
           sleep(400)
@@ -79,7 +79,7 @@ class CancellationBehavior extends munit.FunSuite:
 
   test("link group"):
     val info = Info()
-    Async.blocking:
+    Async.fromSync:
       val promise = Future.Promise[Unit]()
       Async.group:
         startFuture(info, promise.complete(Success(())))
@@ -89,7 +89,7 @@ class CancellationBehavior extends munit.FunSuite:
   test("nested link group"):
     val (info1, info2) = (Info(), Info())
     val (promise1, promise2) = (Future.Promise[Unit](), Future.Promise[Unit]())
-    Async.blocking:
+    Async.fromSync:
       Async.group:
         startFuture(
           info1, {
@@ -108,7 +108,7 @@ class CancellationBehavior extends munit.FunSuite:
   test("link to already cancelled"):
     var x1 = 0
     var x2 = 0
-    Async.blocking:
+    Async.fromSync:
       val f = Future:
         uninterruptible:
           sleep(500)
@@ -124,7 +124,7 @@ class CancellationBehavior extends munit.FunSuite:
 
   test("link to already cancelled awaited"):
     val info = Info()
-    Async.blocking:
+    Async.fromSync:
       val promise = Future.Promise[Unit]()
       Async.group:
         Async.current.group.cancel() // cancel now

--- a/shared/src/test/scala/ChannelBehavior.scala
+++ b/shared/src/test/scala/ChannelBehavior.scala
@@ -29,7 +29,7 @@ class ChannelBehavior extends munit.FunSuite {
   given ExecutionContext = ExecutionContext.global
 
   test("sending is blocking in SyncChannel") {
-    Async.blocking:
+    Async.fromSync:
       val c = SyncChannel[Int]()
       var touched = false
       val f1 = Future:
@@ -46,7 +46,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("sending is nonblocking in empty BufferedChannel") {
-    Async.blocking:
+    Async.fromSync:
       val c = BufferedChannel[Int](1)
       var touched = false
       val f1 = Future:
@@ -63,7 +63,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("sending is blocking in full BufferedChannel") {
-    Async.blocking:
+    Async.fromSync:
       val c = BufferedChannel[Int](3)
       var touched = false
       val f1 = Future:
@@ -84,7 +84,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("read blocks until value is available in SyncChannel") {
-    Async.blocking:
+    Async.fromSync:
       val c = SyncChannel[Int]()
       var touched = false
       val f1 = Future:
@@ -105,7 +105,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("read blocks until value is available in BufferedChannel") {
-    Async.blocking:
+    Async.fromSync:
       val c = BufferedChannel[Int](3)
       var touched = false
       val f1 = Future:
@@ -126,7 +126,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("values arrive in order") {
-    Async.blocking {
+    Async.fromSync {
       for c <- getChannels do
         val f1 = Future:
           for (i <- 0 to 1000)
@@ -162,7 +162,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("reading a closed channel returns Failure(ChannelClosedException)") {
-    Async.blocking:
+    Async.fromSync:
       val channels = getChannels
       channels.foreach(_.close())
       for c <- channels do
@@ -173,7 +173,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("writing to a closed channel throws ChannelClosedException") {
-    Async.blocking:
+    Async.fromSync:
       val channels = getChannels
       channels.foreach(_.close())
       for c <- channels do
@@ -187,7 +187,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("send a lot of values via a channel and check their sum") {
-    Async.blocking:
+    Async.fromSync:
       for (c <- getChannels) {
         var sum = 0L
         val f1 = Future:
@@ -204,7 +204,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("multiple writers, multiple readers") {
-    Async.blocking:
+    Async.fromSync:
       for (c <- getChannels) {
         val f11 = Future:
           for (i <- 1 to 10000)
@@ -248,7 +248,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("race reads") {
-    Async.blocking:
+    Async.fromSync:
       val channels = (0 until 1000).map(_ => SyncChannel[Int]()).toArray
       val sends = channels.toIterator.zipWithIndex.foreach { case (ch, idx) =>
         Future { ch.send(idx) }
@@ -266,7 +266,7 @@ class ChannelBehavior extends munit.FunSuite {
   test("unbounded channels with sync sending") {
     val ch = UnboundedChannel[Int]()
     for i <- 0 to 10 do ch.sendImmediately(i)
-    Async.blocking:
+    Async.fromSync:
       for i <- 0 to 10 do assertEquals(ch.read().right.get, i)
       ch.close()
       try {
@@ -278,7 +278,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("race sends") {
-    Async.blocking:
+    Async.fromSync:
       val ch = SyncChannel[Int]()
       var timesSent = 0
       val race = Async.race(
@@ -297,7 +297,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("race syntax") {
-    Async.blocking:
+    Async.fromSync:
       val a = SyncChannel[Int]()
       val b = SyncChannel[Int]()
 
@@ -321,7 +321,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("ChannelMultiplexer multiplexes - all subscribers read the same stream") {
-    Async.blocking:
+    Async.fromSync:
       val m = ChannelMultiplexer[Int]()
       val c = SyncChannel[Int]()
       m.addPublisher(c)
@@ -345,7 +345,7 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("ChannelMultiplexer multiple readers and writers") {
-    Async.blocking:
+    Async.fromSync:
       val m = ChannelMultiplexer[Int]()
 
       val sendersCount = 3

--- a/shared/src/test/scala/ChannelBehavior.scala
+++ b/shared/src/test/scala/ChannelBehavior.scala
@@ -126,8 +126,8 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("values arrive in order") {
-    for c <- getChannels do
-      Async.blocking {
+    Async.blocking {
+      for c <- getChannels do
         val f1 = Future:
           for (i <- 0 to 1000)
             c.send(i)
@@ -158,7 +158,7 @@ class ChannelBehavior extends munit.FunSuite {
         assertEquals(i1, 1001)
         assertEquals(i2, 3001)
         assertEquals(i3, 5001)
-      }
+    }
   }
 
   test("reading a closed channel returns Failure(ChannelClosedException)") {
@@ -187,9 +187,9 @@ class ChannelBehavior extends munit.FunSuite {
   }
 
   test("send a lot of values via a channel and check their sum") {
-    for (c <- getChannels) {
-      var sum = 0L
-      Async.blocking:
+    Async.blocking:
+      for (c <- getChannels) {
+        var sum = 0L
         val f1 = Future:
           for (i <- 1 to 10000)
             c.send(i)
@@ -200,12 +200,12 @@ class ChannelBehavior extends munit.FunSuite {
 
         f2.awaitResult
         assertEquals(sum, 50005000L)
-    }
+      }
   }
 
   test("multiple writers, multiple readers") {
-    for (c <- getChannels) {
-      Async.blocking:
+    Async.blocking:
+      for (c <- getChannels) {
         val f11 = Future:
           for (i <- 1 to 10000)
             c.send(i)
@@ -244,7 +244,7 @@ class ChannelBehavior extends munit.FunSuite {
         f11.awaitResult
         f12.awaitResult
         f13.awaitResult
-    }
+      }
   }
 
   test("race reads") {
@@ -268,13 +268,13 @@ class ChannelBehavior extends munit.FunSuite {
     for i <- 0 to 10 do ch.sendImmediately(i)
     Async.blocking:
       for i <- 0 to 10 do assertEquals(ch.read().right.get, i)
-    ch.close()
-    try {
-      ch.sendImmediately(0)
-      assert(false)
-    } catch {
-      case _: ChannelClosedException => ()
-    }
+      ch.close()
+      try {
+        ch.sendImmediately(0)
+        assert(false)
+      } catch {
+        case _: ChannelClosedException => ()
+      }
   }
 
   test("race sends") {
@@ -306,13 +306,13 @@ class ChannelBehavior extends munit.FunSuite {
       var valuesSent = 0
       for i <- 1 to 2 do
         Async.select(
-          a.readSource handle { case Right(v) =>
-            assertEquals(v, 0)
-          },
-          b.sendSource(10) handle { case Right(_) =>
-            valuesSent += 1
-            assertEquals(valuesSent, 1)
-          }
+          a.readSource.handle: v =>
+            assertEquals(v, Right(0)),
+          b.sendSource(10)
+            .handle: v =>
+              assert(v.isRight)
+              valuesSent += 1
+              assertEquals(valuesSent, 1)
         )
 
       a.close()

--- a/shared/src/test/scala/ChannelBehavior.scala
+++ b/shared/src/test/scala/ChannelBehavior.scala
@@ -347,7 +347,6 @@ class ChannelBehavior extends munit.FunSuite {
   test("ChannelMultiplexer multiple readers and writers") {
     Async.blocking:
       val m = ChannelMultiplexer[Int]()
-      val start = java.util.concurrent.CountDownLatch(5)
 
       val sendersCount = 3
       val sendersMessage = 4

--- a/shared/src/test/scala/CountdownLatch.scala
+++ b/shared/src/test/scala/CountdownLatch.scala
@@ -1,0 +1,29 @@
+package gears.async
+
+import scala.collection.mutable
+
+/** A simple and possibly very inefficient countdown latch */
+class CountdownLatch(private var count: Int) extends Async.OriginalSource[Unit]:
+  val listeners = mutable.Set[Listener[Unit]]()
+
+  override def poll(l: Listener[Unit]) =
+    if count == 0 then l.completeNow((), this)
+    else false
+
+  override def addListener(l: Listener[Unit]) = synchronized:
+    listeners += l
+
+  override def dropListener(l: Listener[Unit]) = synchronized:
+    listeners -= l
+
+  def done() =
+    val toWake =
+      synchronized:
+        assert(count > 0, "All countdown has been completed")
+        count -= 1
+        if count == 0 then
+          val ls = listeners.toSeq
+          listeners.clear()
+          ls
+        else Seq.empty
+    toWake.foreach(_.completeNow((), this))

--- a/shared/src/test/scala/FutureBehavior.scala
+++ b/shared/src/test/scala/FutureBehavior.scala
@@ -97,23 +97,24 @@ class FutureBehavior extends munit.FunSuite {
 
   test("orWithCancel of 2 futures") {
     Async.blocking:
-      var touched = 0
-      Future {
-        sleep(200)
-        touched += 1
-      }.or(Future {
-        10
-      }).awaitResult
-      sleep(300)
-      assertEquals(touched, 1)
-    Async.blocking:
-      var touched = 0
-      Future {
-        sleep(200)
-        touched += 1
-      }.orWithCancel(Future { 10 }).awaitResult
-      sleep(300)
-      assertEquals(touched, 0)
+      Async.group:
+        var touched = 0
+        Future {
+          sleep(200)
+          touched += 1
+        }.or(Future {
+          10
+        }).awaitResult
+        sleep(300)
+        assertEquals(touched, 1)
+      Async.group:
+        var touched = 0
+        Future {
+          sleep(200)
+          touched += 1
+        }.orWithCancel(Future { 10 }).awaitResult
+        sleep(300)
+        assertEquals(touched, 0)
   }
 
   test("zip") {
@@ -181,7 +182,7 @@ class FutureBehavior extends munit.FunSuite {
       }
       f.cancel()
       f.awaitResult match
-        case _: Failure[CancellationException] => ()
+        case Failure(_: CancellationException) => ()
         case _                                 => assert(false)
   }
 
@@ -327,7 +328,7 @@ class FutureBehavior extends munit.FunSuite {
       (1 to 20)
         .map(_ => Future { fut.cancel() })
         .awaitAll
-    assertEquals(num.get(), 1)
+      assertEquals(num.get(), 1)
   }
 
   test("Future.withResolver cancel handler is not run after being completed") {

--- a/shared/src/test/scala/FutureBehavior.scala
+++ b/shared/src/test/scala/FutureBehavior.scala
@@ -440,8 +440,7 @@ class FutureBehavior extends munit.FunSuite {
       val ch = gears.async.UnboundedChannel[Int]()
       val reader = Future:
         gears.async.uninterruptible:
-          val i = ch.read().right.get
-          println(i)
+          ch.read().right.get
       reader.cancel()
       ch.sendImmediately(1)
       ch.sendImmediately(2)

--- a/shared/src/test/scala/FutureBehavior.scala
+++ b/shared/src/test/scala/FutureBehavior.scala
@@ -1,14 +1,14 @@
+import gears.async.*
 import gears.async.AsyncOperations.*
 import gears.async.Future.{Promise, zip}
-import gears.async.Listener
 import gears.async.default.given
-import gears.async.{Async, Future, Task, TaskSchedule, uninterruptible}
 
 import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 import scala.collection.mutable.Set
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
 import scala.util.Random
 import scala.util.{Failure, Success, Try}
 
@@ -211,8 +211,8 @@ class FutureBehavior extends munit.FunSuite {
       }
       assertEquals(f.await, 10)
       assertEquals(zombieModifiedThis, false)
-    Thread.sleep(300)
-    assertEquals(zombieModifiedThis, true)
+      AsyncOperations.sleep(300.millis)
+      assertEquals(zombieModifiedThis, true)
   }
 
   // test("zip on tuples with EmptyTuple") {

--- a/shared/src/test/scala/FutureBehavior.scala
+++ b/shared/src/test/scala/FutureBehavior.scala
@@ -16,7 +16,7 @@ class FutureBehavior extends munit.FunSuite {
   given ExecutionContext = ExecutionContext.global
 
   test("Old test") {
-    Async.blocking:
+    Async.fromSync:
       val x = Future:
         val a = Future {
           22
@@ -59,7 +59,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("Constant returns") {
-    Async.blocking:
+    Async.fromSync:
       for (i <- -5 to 5)
         val f1 = Future { i }
         val f2 = Future.now(Success(i))
@@ -68,13 +68,13 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("Future.now returning") {
-    Async.blocking:
+    Async.fromSync:
       val f = Future.now(Success(116))
       assertEquals(f.await, 116)
   }
 
   test("Constant future with timeout") {
-    Async.blocking:
+    Async.fromSync:
       val f = Future {
         sleep(50)
         55
@@ -83,7 +83,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("or") {
-    Async.blocking:
+    Async.fromSync:
       val error = new AssertionError()
       val fail = Future.now(Failure(error))
       val fail1 = Future.now(Failure(error))
@@ -96,7 +96,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("orWithCancel of 2 futures") {
-    Async.blocking:
+    Async.fromSync:
       Async.group:
         var touched = 0
         Future {
@@ -118,7 +118,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("zip") {
-    Async.blocking:
+    Async.fromSync:
       val error = new AssertionError()
       val fail = Future.now(Failure(error))
       val fail1 = Future.now(Failure(error))
@@ -131,20 +131,20 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("result wraps exceptions") {
-    Async.blocking:
+    Async.fromSync:
       for (i <- -5 to 5)
         val error = new AssertionError(i)
         assertEquals(Future { throw error }.awaitResult, Failure(error))
   }
 
   test("result wraps values") {
-    Async.blocking:
+    Async.fromSync:
       for (i <- -5 to 5)
         assertEquals(Future { i }.awaitResult, Success(i))
   }
 
   test("value propagates exceptions exceptions through futures") {
-    Async.blocking:
+    Async.fromSync:
       val e = AssertionError(1151)
       val f = Future {
         val f1 = Future {
@@ -160,7 +160,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("futures can be nested") {
-    Async.blocking:
+    Async.fromSync:
       val z = Future {
         sleep(Random.between(0, 15L))
         Future {
@@ -175,7 +175,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("future are cancelled via .interrupt() and not checking the flag in async") {
-    Async.blocking:
+    Async.fromSync:
       val f = Future {
         sleep(150L)
         10
@@ -187,7 +187,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("future should cancel its group when the main body is completed") {
-    Async.blocking:
+    Async.fromSync:
       var touched = false
       val fut = Future:
         Future:
@@ -200,9 +200,9 @@ class FutureBehavior extends munit.FunSuite {
       assertEquals(touched, false)
   }
 
-  test("zombie threads exist and run to completion after the Async.blocking barrier") {
+  test("zombie threads exist and run to completion after the Async.fromSync barrier") {
     var zombieModifiedThis = false
-    Async.blocking:
+    Async.fromSync:
       val f = Future {
         Future {
           sleep(200)
@@ -217,7 +217,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   // test("zip on tuples with EmptyTuple") {
-  //   Async.blocking:
+  //   Async.fromSync:
   //     val z1 = Future { sleep(500); 10 } *: Future { sleep(10); 222 } *: Future { sleep(150); 333 } *: Future {
   //       EmptyTuple
   //     }
@@ -225,14 +225,14 @@ class FutureBehavior extends munit.FunSuite {
   // }
 
   // test("zip on tuples with last zip") {
-  //   Async.blocking:
+  //   Async.fromSync:
   //     val z1 = Future { 10 } *: Future { 222 }.zip(Future { 333 })
   //     assertEquals(z1.await, (10, 222, 333))
   // }
 
   // test("zip(3) first error") {
   //   for (_ <- 1 to 20)
-  //     Async.blocking:
+  //     Async.fromSync:
   //       val e1 = AssertionError(111)
   //       val e2 = AssertionError(211)
   //       val e3 = AssertionError(311)
@@ -252,7 +252,7 @@ class FutureBehavior extends munit.FunSuite {
   // }
 
   test("cancelled futures return the same constant CancellationException with no stack attached".ignore) {
-    Async.blocking:
+    Async.fromSync:
       val futures = List(
         Future { sleep(100); 1 },
         Future { sleep(100); 1 },
@@ -272,7 +272,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("noninterruptible future immediate return") {
-    Async.blocking:
+    Async.fromSync:
       for (i <- -5 to 5)
         var j = -1
         uninterruptible {
@@ -284,7 +284,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("Noninterruptible future cannot be interrupted immediately but throws later") {
-    Async.blocking:
+    Async.fromSync:
       var touched = false
       val f = Future {
         uninterruptible {
@@ -302,7 +302,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("Promise can be cancelled") {
-    Async.blocking:
+    Async.fromSync:
       val p = Promise[Int]()
       val f = p.asFuture
       f.cancel()
@@ -313,7 +313,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("Promise can't be cancelled after completion") {
-    Async.blocking:
+    Async.fromSync:
       val p = Promise[Int]()
       p.complete(Success(10))
       val f = p.asFuture
@@ -324,7 +324,7 @@ class FutureBehavior extends munit.FunSuite {
   test("Future.withResolver cancel handler is run once") {
     val num = AtomicInteger(0)
     val fut = Future.withResolver { _.onCancel { () => num.incrementAndGet() } }
-    Async.blocking:
+    Async.fromSync:
       (1 to 20)
         .map(_ => Future { fut.cancel() })
         .awaitAll
@@ -353,7 +353,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("Nesting of cancellations") {
-    Async.blocking:
+    Async.fromSync:
       var touched1 = false
       var touched2 = false
       val f1 = Future {
@@ -371,7 +371,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("future collector") {
-    Async.blocking:
+    Async.fromSync:
       val range = (0 to 10)
       val futs = range.map(i => Future { sleep(i * 100); i })
       val collector = Future.Collector(futs*)
@@ -382,7 +382,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("mutable collector") {
-    Async.blocking:
+    Async.fromSync:
       val range = (0 to 10)
       val futs = range.map(i => Future { sleep(i * 100); i })
       val collector = Future.MutableCollector(futs*)
@@ -400,7 +400,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("future collection: awaitAll*") {
-    Async.blocking:
+    Async.fromSync:
       val range = (0 to 10)
       def futs = range.map(i => Future { sleep(i * 100); i })
       assertEquals(futs.awaitAll, range.toSeq)
@@ -416,7 +416,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("future collection: awaitFirst*") {
-    Async.blocking:
+    Async.fromSync:
       val range = (0 to 10)
       def futs = range.map(i => Future { sleep(i * 100); i })
       assert(range contains futs.awaitFirst)
@@ -436,7 +436,7 @@ class FutureBehavior extends munit.FunSuite {
   }
 
   test("uninterruptible should continue even when Future is cancelled") {
-    Async.blocking:
+    Async.fromSync:
       val ch = gears.async.UnboundedChannel[Int]()
       val reader = Future:
         gears.async.uninterruptible:

--- a/shared/src/test/scala/ListenerBehavior.scala
+++ b/shared/src/test/scala/ListenerBehavior.scala
@@ -19,7 +19,7 @@ class ListenerBehavior extends munit.FunSuite:
   test("race two futures"):
     val prom1 = Promise[Unit]()
     val prom2 = Promise[Unit]()
-    Async.blocking:
+    Async.fromSync:
       val raced = race(Future { prom1.await; 10 }, Future { prom2.await; 20 })
       assert(!raced.poll(Listener.acceptingListener((x, _) => fail(s"race uncomplete $x"))))
       prom1.complete(Success(()))
@@ -107,7 +107,7 @@ class ListenerBehavior extends munit.FunSuite:
     val lock = source1.listener.get.acquireLock()
     assertEquals(lock, true)
 
-    Async.blocking:
+    Async.fromSync:
       val l2 = source2.listener.get
       val f = Future(assertEquals(l2.acquireLock(), false))
       source1.completeWith(1)
@@ -123,7 +123,7 @@ class ListenerBehavior extends munit.FunSuite:
 
     val l2 = source2.listener.get
 
-    Async.blocking:
+    Async.fromSync:
       val f1 = Future(source1.completeNowWith(1))
       listener.sleeping.await
       listener.continue()
@@ -166,7 +166,7 @@ class ListenerBehavior extends munit.FunSuite:
     val other = new NumberedTestListener(true, false, 1)
     val s1listener = source1.listener.get
 
-    Async.blocking:
+    Async.fromSync:
       val f1 = Future(lockBoth(s1listener, other))
       other.sleeping.await
       assert(source2.listener.get.completeNow(1, source2))

--- a/shared/src/test/scala/ListenerBehavior.scala
+++ b/shared/src/test/scala/ListenerBehavior.scala
@@ -133,10 +133,9 @@ class ListenerBehavior extends munit.FunSuite:
         completed
       assert(f1.await || f2.await)
       assert(!f1.await || !f2.await)
-      println(s"${f1.await} ${f2.await}")
 
-    assert(source1.listener.isEmpty)
-    assert(source2.listener.isEmpty)
+      assert(source1.listener.isEmpty)
+      assert(source2.listener.isEmpty)
 
   test("race polling"):
     val source1 = new Async.Source[Int]():

--- a/shared/src/test/scala/ListenerBehavior.scala
+++ b/shared/src/test/scala/ListenerBehavior.scala
@@ -252,7 +252,8 @@ private class TestListener(expected: Int)(using asst: munit.Assertions) extends 
     asst.assertEquals(data, expected)
 
 private class NumberedTestListener private (sleep: AtomicBoolean, fail: Boolean, expected: Int)(using munit.Assertions)
-    extends TestListener(expected):
+    extends TestListener(expected)
+    with TestListenerImpl:
   // A promise that is waited for inside `lock` until `continue` is called.
   private val waiter = if sleep.get() then Some(Promise[Unit]()) else None
   // A promise that is resolved right before the lock starts waiting for `waiter`.

--- a/shared/src/test/scala/ResourceBehavior.scala
+++ b/shared/src/test/scala/ResourceBehavior.scala
@@ -15,13 +15,13 @@ import concurrent.duration.DurationInt
 class ResourceBehavior extends munit.FunSuite {
 
   def use(container: Container) =
-    Async.blocking:
+    Async.fromSync:
       container.assertInitial()
       container.res.use(_ => container.waitAcquired())
       container.waitReleased()
 
   def allocated(container: Container) =
-    Async.blocking:
+    Async.fromSync:
       container.assertInitial()
       val res = container.res.allocated
       try container.waitAcquired()
@@ -29,7 +29,7 @@ class ResourceBehavior extends munit.FunSuite {
       container.waitReleased()
 
   def mappedUse(container: Container) =
-    Async.blocking:
+    Async.fromSync:
       val res = container.res.map: _ =>
         container.waitAcquired()
         "a"
@@ -40,7 +40,7 @@ class ResourceBehavior extends munit.FunSuite {
       container.waitReleased()
 
   def mappedAllocated(container: Container) =
-    Async.blocking:
+    Async.fromSync:
       val res = container.res.map: _ =>
         container.waitAcquired()
         "a"
@@ -64,7 +64,7 @@ class ResourceBehavior extends munit.FunSuite {
   do test(s"$implName - $testName")(testCase(impl()))
 
   test("leak future") {
-    Async.blocking:
+    Async.fromSync:
       val container = AsyncResContainer()
       val res = Async.group:
         container.res.allocated

--- a/shared/src/test/scala/RetryBehavior.scala
+++ b/shared/src/test/scala/RetryBehavior.scala
@@ -13,7 +13,7 @@ import Retry.Delay
 class RetryBehavior extends munit.FunSuite {
   test("Exponential backoff(2) 50ms, 5 times total schedule"):
     val start = System.currentTimeMillis()
-    Async.blocking:
+    Async.fromSync:
       var i = 0
       Retry.untilSuccess.withDelay(Delay.backoff(1.second, 50.millis)):
         i += 1
@@ -24,7 +24,7 @@ class RetryBehavior extends munit.FunSuite {
 
   test("UntilSuccess 150ms"):
     val start = System.currentTimeMillis()
-    Async.blocking:
+    Async.fromSync:
       var i = 0
       val ret = Retry.untilSuccess.withDelay(Delay.constant(150.millis)):
         if (i < 4) then
@@ -39,7 +39,7 @@ class RetryBehavior extends munit.FunSuite {
   test("UntilFailure 150ms") {
     val start = System.currentTimeMillis()
     val ex = AssertionError()
-    Async.blocking:
+    Async.fromSync:
       var i = 0
       val ret = Try(Retry.untilFailure.withDelay(Delay.constant(150.millis)):
         if (i < 4) then

--- a/shared/src/test/scala/RetryBehavior.scala
+++ b/shared/src/test/scala/RetryBehavior.scala
@@ -18,9 +18,9 @@ class RetryBehavior extends munit.FunSuite {
       Retry.untilSuccess.withDelay(Delay.backoff(1.second, 50.millis)):
         i += 1
         if i < 5 then throw Exception("try again!")
-    val end = System.currentTimeMillis()
-    assert(end - start >= 50 + 100 + 200 + 400)
-    assert(end - start < 50 + 100 + 200 + 400 + 800)
+      val end = System.currentTimeMillis()
+      assert(end - start >= 50 + 100 + 200 + 400)
+      assert(end - start < 50 + 100 + 200 + 400 + 800)
 
   test("UntilSuccess 150ms"):
     val start = System.currentTimeMillis()
@@ -32,9 +32,9 @@ class RetryBehavior extends munit.FunSuite {
           throw AssertionError()
         else i
       assertEquals(ret, 4)
-    val end = System.currentTimeMillis()
-    assert(end - start >= 4 * 150)
-    assert(end - start < 5 * 150)
+      val end = System.currentTimeMillis()
+      assert(end - start >= 4 * 150)
+      assert(end - start < 5 * 150)
 
   test("UntilFailure 150ms") {
     val start = System.currentTimeMillis()
@@ -48,9 +48,9 @@ class RetryBehavior extends munit.FunSuite {
         else throw ex
       )
       assertEquals(ret, Failure(ex))
-    val end = System.currentTimeMillis()
-    assert(end - start >= 4 * 150)
-    assert(end - start < 5 * 150)
+      val end = System.currentTimeMillis()
+      assert(end - start >= 4 * 150)
+      assert(end - start < 5 * 150)
   }
 
   test("delay policies") {

--- a/shared/src/test/scala/SchedulerBehavior.scala
+++ b/shared/src/test/scala/SchedulerBehavior.scala
@@ -9,7 +9,7 @@ import concurrent.duration.DurationInt
 
 class SchedulerBehavior extends munit.FunSuite {
   test("schedule cancellation works") {
-    Async.blocking:
+    Async.fromSync:
       var bodyRan = false
       val cancellable = Async.current.scheduler.schedule(1.seconds, () => bodyRan = true)
 
@@ -21,14 +21,14 @@ class SchedulerBehavior extends munit.FunSuite {
   }
 
   test("schedule cancellation doesn't abort inner code") {
-    Async.blocking:
+    Async.fromSync:
       var bodyRan = false
       val fut = Promise[Unit]()
       val cancellable = Async.current.scheduler.schedule(
         50.milliseconds,
         () =>
           fut.complete(Success(()))
-          Async.blocking:
+          Async.fromSync:
             sleep(500)
             bodyRan = true
       )
@@ -43,7 +43,7 @@ class SchedulerBehavior extends munit.FunSuite {
   }
 
   test("execute works") {
-    Async.blocking:
+    Async.fromSync:
       val fut = Promise[Int]()
 
       Async.current.scheduler.execute: () =>

--- a/shared/src/test/scala/SemaphoreBehavior.scala
+++ b/shared/src/test/scala/SemaphoreBehavior.scala
@@ -46,22 +46,23 @@ class SemaphoreBehavior extends munit.FunSuite {
   }
 
   test("no release high-numbered semaphore") {
-    val futs = Async.blocking:
-      val sem = Semaphore(100)
-      val count = AtomicInteger()
+    Async.blocking:
+      val futs =
+        val sem = Semaphore(100)
+        val count = AtomicInteger()
 
-      val futs = Seq.fill(1_000)(Future {
-        sem.acquire()
-        count.incrementAndGet()
-      })
+        val futs = Seq.fill(1_000)(Future {
+          sem.acquire()
+          count.incrementAndGet()
+        })
 
-      while count.get() < 100 do Thread.`yield`()
-      sleep(100)
-      assertEquals(count.get(), 100)
-      futs
-    val (succ, fail) = futs.partition(f => f.poll().get.isSuccess)
-    assertEquals(succ.size, 100)
-    assertEquals(fail.size, 900)
+        while count.get() < 100 do Thread.`yield`()
+        sleep(100)
+        assertEquals(count.get(), 100)
+        futs
+      val (succ, fail) = futs.partition(f => f.poll().get.isSuccess)
+      assertEquals(succ.size, 100)
+      assertEquals(fail.size, 900)
   }
 
 }

--- a/shared/src/test/scala/SemaphoreBehavior.scala
+++ b/shared/src/test/scala/SemaphoreBehavior.scala
@@ -13,7 +13,7 @@ import concurrent.duration.DurationInt
 class SemaphoreBehavior extends munit.FunSuite {
 
   test("single threaded semaphore") {
-    Async.blocking:
+    Async.fromSync:
       val sem = Semaphore(2)
       sem.acquire().release()
       sem.acquire()
@@ -21,7 +21,7 @@ class SemaphoreBehavior extends munit.FunSuite {
   }
 
   test("single threaded semaphore blocked") {
-    Async.blocking:
+    Async.fromSync:
       val sem = Semaphore(2)
       val guard = sem.acquire()
       sem.acquire()
@@ -32,7 +32,7 @@ class SemaphoreBehavior extends munit.FunSuite {
   }
 
   test("binary semaphore") {
-    Async.blocking:
+    Async.fromSync:
       val sem = Semaphore(1)
       var count = 0
 
@@ -47,7 +47,7 @@ class SemaphoreBehavior extends munit.FunSuite {
   }
 
   test("no release high-numbered semaphore") {
-    Async.blocking:
+    Async.fromSync:
       val futs =
         Async.group:
           val sem = Semaphore(100)

--- a/shared/src/test/scala/SourceBehavior.scala
+++ b/shared/src/test/scala/SourceBehavior.scala
@@ -15,7 +15,7 @@ class SourceBehavior extends munit.FunSuite {
 
   test("onComplete register after completion runs immediately") {
     @volatile var itRan = false
-    Async.blocking:
+    Async.fromSync:
       val f = Future.now(Success(10))
       f.onComplete(Listener.acceptingListener { (_, _) => itRan = true })
       assertEquals(itRan, true)
@@ -23,7 +23,7 @@ class SourceBehavior extends munit.FunSuite {
 
   test("poll is asynchronous") {
     @volatile var itRan = false
-    Async.blocking:
+    Async.fromSync:
       val f = Future { sleep(50); 10 }
       f.poll(Listener.acceptingListener { (_, _) => itRan = true })
       assertEquals(itRan, false)
@@ -31,7 +31,7 @@ class SourceBehavior extends munit.FunSuite {
 
   test("onComplete is asynchronous") {
     @volatile var itRan = false
-    Async.blocking:
+    Async.fromSync:
       val f = Future {
         sleep(50); 10
       }
@@ -41,7 +41,7 @@ class SourceBehavior extends munit.FunSuite {
 
   test("await is synchronous") {
     @volatile var itRan = false
-    Async.blocking:
+    Async.fromSync:
       val f = Future {
         sleep(250);
         10
@@ -53,7 +53,7 @@ class SourceBehavior extends munit.FunSuite {
   }
 
   test("sources wait on children sources when they block") {
-    Async.blocking:
+    Async.fromSync:
       val timeBefore = System.currentTimeMillis()
       val f = Future {
         sleep(50);
@@ -71,7 +71,7 @@ class SourceBehavior extends munit.FunSuite {
 
   test("sources do not wait on zombie sources (which are killed at the end of Async.Blocking)") {
     val timeBefore = System.currentTimeMillis()
-    Async.blocking:
+    Async.fromSync:
       val f = Future {
         Future { sleep(300) }
         1
@@ -81,7 +81,7 @@ class SourceBehavior extends munit.FunSuite {
   }
 
   test("poll()") {
-    Async.blocking:
+    Async.fromSync:
       val f: Future[Int] = Future {
         sleep(100)
         1
@@ -92,7 +92,7 @@ class SourceBehavior extends munit.FunSuite {
   }
 
   test("onComplete() fires") {
-    Async.blocking:
+    Async.fromSync:
       @volatile var aRan = false
       @volatile var bRan = false
       val f = Future {
@@ -110,7 +110,7 @@ class SourceBehavior extends munit.FunSuite {
   }
 
   test("dropped onComplete() listener does not fire") {
-    Async.blocking:
+    Async.fromSync:
       @volatile var aRan = false
       @volatile var bRan = false
       val f = Future {
@@ -130,7 +130,7 @@ class SourceBehavior extends munit.FunSuite {
   }
 
   test("transform values with") {
-    Async.blocking:
+    Async.fromSync:
       val f: Future[Int] = Future { 10 }
       assertEquals(
         f.transformValuesWith:
@@ -150,7 +150,7 @@ class SourceBehavior extends munit.FunSuite {
   }
 
   test("all listeners in chain fire") {
-    Async.blocking:
+    Async.fromSync:
       var aRan = Future.Promise[Unit]()
       var bRan = Future.Promise[Unit]()
       val wait = Future.Promise[Unit]()
@@ -171,7 +171,7 @@ class SourceBehavior extends munit.FunSuite {
 
   test("either") {
     @volatile var touched = false
-    Async.blocking:
+    Async.fromSync:
       val f1 = Future { sleep(300); touched = true; 10 }
       val f2 = Future { sleep(50); 40 }
       val g = either(f1, f2).awaitResult
@@ -181,12 +181,12 @@ class SourceBehavior extends munit.FunSuite {
   }
 
   test("source values") {
-    Async.blocking:
+    Async.fromSync:
       val src = Async.Source.values(1, 2)
       assertEquals(src.awaitResult, 1)
       assertEquals(src.awaitResult, 2)
 
-    Async.blocking:
+    Async.fromSync:
       val src = Async.Source.values(1)
       assertEquals(src.awaitResult, 1)
       assertEquals(

--- a/shared/src/test/scala/SourceBehavior.scala
+++ b/shared/src/test/scala/SourceBehavior.scala
@@ -1,6 +1,6 @@
+import gears.async.*
 import gears.async.AsyncOperations.*
 import gears.async.default.given
-import gears.async.{Async, Future, Listener, withTimeout}
 
 import java.util.concurrent.CancellationException
 import scala.concurrent.ExecutionContext
@@ -48,7 +48,7 @@ class SourceBehavior extends munit.FunSuite {
       }
       f.onComplete(Listener.acceptingListener { (_, _) => itRan = true })
       f.await
-      Thread.sleep(100) // onComplete of await and manual may be scheduled
+      AsyncOperations.sleep(100) // onComplete of await and manual may be scheduled
       assertEquals(itRan, true)
   }
 
@@ -104,7 +104,7 @@ class SourceBehavior extends munit.FunSuite {
       assertEquals(aRan, false)
       assertEquals(bRan, false)
       f.await
-      Thread.sleep(100) // onComplete of await and manual may be scheduled
+      AsyncOperations.sleep(100) // onComplete of await and manual may be scheduled
       assertEquals(aRan, true)
       assertEquals(bRan, true)
   }
@@ -124,7 +124,7 @@ class SourceBehavior extends munit.FunSuite {
       assertEquals(bRan, false)
       f.dropListener(l)
       f.await
-      Thread.sleep(100) // onComplete of await and manual may be scheduled
+      AsyncOperations.sleep(100) // onComplete of await and manual may be scheduled
       assertEquals(aRan, false)
       assertEquals(bRan, true)
   }

--- a/shared/src/test/scala/SourceBehavior.scala
+++ b/shared/src/test/scala/SourceBehavior.scala
@@ -18,7 +18,7 @@ class SourceBehavior extends munit.FunSuite {
     Async.blocking:
       val f = Future.now(Success(10))
       f.onComplete(Listener.acceptingListener { (_, _) => itRan = true })
-    assertEquals(itRan, true)
+      assertEquals(itRan, true)
   }
 
   test("poll is asynchronous") {
@@ -76,8 +76,8 @@ class SourceBehavior extends munit.FunSuite {
         Future { sleep(300) }
         1
       }.await
-    val timeAfter = System.currentTimeMillis()
-    assert(timeAfter - timeBefore < 290)
+      val timeAfter = System.currentTimeMillis()
+      assert(timeAfter - timeBefore < 290)
   }
 
   test("poll()") {
@@ -132,9 +132,21 @@ class SourceBehavior extends munit.FunSuite {
   test("transform values with") {
     Async.blocking:
       val f: Future[Int] = Future { 10 }
-      assertEquals(f.transformValuesWith({ case Success(i) => i + 1 }).awaitResult, 11)
+      assertEquals(
+        f.transformValuesWith:
+          case Success(i) => i + 1
+          case _          => -1
+        .awaitResult,
+        11
+      )
       val g: Future[Int] = Future.now(Failure(AssertionError(1123)))
-      assertEquals(g.transformValuesWith({ case Failure(_) => 17 }).awaitResult, 17)
+      assertEquals(
+        g.transformValuesWith:
+          case Failure(_) => 17
+          case _          => -1
+        .awaitResult,
+        17
+      )
   }
 
   test("all listeners in chain fire") {

--- a/shared/src/test/scala/Stress.scala
+++ b/shared/src/test/scala/Stress.scala
@@ -8,13 +8,15 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration._
 
 class StressTest extends munit.FunSuite:
+  override val munitTimeout: Duration = 10.minutes
+
   test("survives a stress test that hammers on creating futures") {
     val total = 200_000L
-    Seq[Long](1, 2, 4, 16, 10000).foreach: parallelism =>
-      val k = AtomicInteger(0)
-      def compute(using Async) =
-        k.incrementAndGet()
-      Async.blocking:
+    Async.blocking:
+      Seq[Long](1, 2, 4, 16, 10000).foreach: parallelism =>
+        val k = AtomicInteger(0)
+        def compute(using Async) =
+          k.incrementAndGet()
         val collector = MutableCollector((1L to parallelism).map(_ => Future { compute })*)
         var sum = 0L
         for i <- parallelism + 1 to total do

--- a/shared/src/test/scala/Stress.scala
+++ b/shared/src/test/scala/Stress.scala
@@ -12,7 +12,7 @@ class StressTest extends munit.FunSuite:
 
   test("survives a stress test that hammers on creating futures") {
     val total = 200_000L
-    Async.blocking:
+    Async.fromSync:
       Seq[Long](1, 2, 4, 16, 10000).foreach: parallelism =>
         val k = AtomicInteger(0)
         def compute(using Async) =
@@ -29,7 +29,7 @@ class StressTest extends munit.FunSuite:
   test("survives a stress test that hammers on suspending") {
     val total = 100_000L
     val parallelism = 5000L
-    Async.blocking:
+    Async.fromSync:
       val sleepy =
         val timer = Timer(1.second)
         Future { timer.run() }

--- a/shared/src/test/scala/TaskScheduleBehavior.scala
+++ b/shared/src/test/scala/TaskScheduleBehavior.scala
@@ -20,7 +20,7 @@ class TaskScheduleBehavior extends munit.FunSuite {
 
   test("Every 100ms, 3 times total schedule") {
     val m = TimeMeasure()
-    Async.blocking:
+    Async.fromSync:
       var i = 0
       val f = Task {
         i += 1
@@ -33,7 +33,7 @@ class TaskScheduleBehavior extends munit.FunSuite {
 
   test("Exponential backoff(2) 50ms, 5 times total schedule") {
     val m = TimeMeasure()
-    Async.blocking:
+    Async.fromSync:
       var i = 0
       val f = Task {
         i += 1
@@ -46,7 +46,7 @@ class TaskScheduleBehavior extends munit.FunSuite {
 
   test("Fibonacci backoff 10ms, 6 times total schedule") {
     val m = TimeMeasure()
-    Async.blocking:
+    Async.fromSync:
       var i = 0
       val f = Task {
         i += 1
@@ -59,7 +59,7 @@ class TaskScheduleBehavior extends munit.FunSuite {
 
   test("UntilSuccess 150ms") {
     val m = TimeMeasure()
-    Async.blocking:
+    Async.fromSync:
       var i = 0
       val t = Task {
         if (i < 4) {
@@ -76,7 +76,7 @@ class TaskScheduleBehavior extends munit.FunSuite {
   test("UntilFailure 150ms") {
     val m = TimeMeasure()
     val ex = AssertionError()
-    Async.blocking:
+    Async.fromSync:
       var i = 0
       val t = Task {
         if (i < 4) {

--- a/shared/src/test/scala/TaskScheduleBehavior.scala
+++ b/shared/src/test/scala/TaskScheduleBehavior.scala
@@ -10,8 +10,16 @@ import Future.zip
 class TaskScheduleBehavior extends munit.FunSuite {
   given ExecutionContext = ExecutionContext.global
 
+  case class TimeMeasure(start: Long = System.currentTimeMillis()):
+    inline def assertTimeLessThan(millis: Long)(using loc: munit.Location) =
+      val `end` = System.currentTimeMillis()
+      assert(`end` - start < millis, s"Expected less than ${millis}ms passed, got ${`end` - start}ms")
+    inline def assertTimeAtLeast(millis: Long)(using loc: munit.Location) =
+      val `end` = System.currentTimeMillis()
+      assert(`end` - start >= millis, s"Expected at least ${millis}ms passed, got ${`end` - start}ms")
+
   test("Every 100ms, 3 times total schedule") {
-    val start = System.currentTimeMillis()
+    val m = TimeMeasure()
     Async.blocking:
       var i = 0
       val f = Task {
@@ -19,13 +27,12 @@ class TaskScheduleBehavior extends munit.FunSuite {
       }.schedule(TaskSchedule.Every(100, 3)).start()
       f.awaitResult
       assertEquals(i, 3)
-    val end = System.currentTimeMillis()
-    assert(end - start >= 200)
-    assert(end - start < 300)
+      m.assertTimeAtLeast(200)
+      m.assertTimeLessThan(300)
   }
 
   test("Exponential backoff(2) 50ms, 5 times total schedule") {
-    val start = System.currentTimeMillis()
+    val m = TimeMeasure()
     Async.blocking:
       var i = 0
       val f = Task {
@@ -33,13 +40,12 @@ class TaskScheduleBehavior extends munit.FunSuite {
       }.schedule(TaskSchedule.ExponentialBackoff(50, 2, 5)).start()
       f.awaitResult
       assertEquals(i, 5)
-    val end = System.currentTimeMillis()
-    assert(end - start >= 50 + 100 + 200 + 400)
-    assert(end - start < 50 + 100 + 200 + 400 + 800)
+      m.assertTimeAtLeast(50 + 100 + 200 + 400)
+      m.assertTimeLessThan(50 + 100 + 200 + 400 + 800)
   }
 
   test("Fibonacci backoff 10ms, 6 times total schedule") {
-    val start = System.currentTimeMillis()
+    val m = TimeMeasure()
     Async.blocking:
       var i = 0
       val f = Task {
@@ -47,13 +53,12 @@ class TaskScheduleBehavior extends munit.FunSuite {
       }.schedule(TaskSchedule.FibonacciBackoff(10, 6)).start()
       f.awaitResult
       assertEquals(i, 6)
-    val end = System.currentTimeMillis()
-    assert(end - start >= 0 + 10 + 10 + 20 + 30 + 50)
-    assert(end - start < 0 + 10 + 10 + 20 + 30 + 50 + 80)
+      m.assertTimeAtLeast(0 + 10 + 10 + 20 + 30 + 50)
+      m.assertTimeLessThan(0 + 10 + 10 + 20 + 30 + 50 + 80)
   }
 
   test("UntilSuccess 150ms") {
-    val start = System.currentTimeMillis()
+    val m = TimeMeasure()
     Async.blocking:
       var i = 0
       val t = Task {
@@ -64,13 +69,12 @@ class TaskScheduleBehavior extends munit.FunSuite {
       }
       val ret = t.schedule(TaskSchedule.RepeatUntilSuccess(150)).start().awaitResult
       assertEquals(ret.get.get, 4)
-    val end = System.currentTimeMillis()
-    assert(end - start >= 4 * 150)
-    assert(end - start < 5 * 150)
+      m.assertTimeAtLeast(4 * 150)
+      m.assertTimeLessThan(5 * 150)
   }
 
   test("UntilFailure 150ms") {
-    val start = System.currentTimeMillis()
+    val m = TimeMeasure()
     val ex = AssertionError()
     Async.blocking:
       var i = 0
@@ -82,9 +86,8 @@ class TaskScheduleBehavior extends munit.FunSuite {
       }
       val ret = t.schedule(TaskSchedule.RepeatUntilFailure(150)).start().awaitResult
       assertEquals(ret.get, Failure(ex))
-    val end = System.currentTimeMillis()
-    assert(end - start >= 4 * 150)
-    assert(end - start < 5 * 150)
+      m.assertTimeAtLeast(4 * 150)
+      m.assertTimeLessThan(5 * 150)
   }
 
 }

--- a/shared/src/test/scala/TimerBehavior.scala
+++ b/shared/src/test/scala/TimerBehavior.scala
@@ -31,9 +31,9 @@ class TimerBehavior extends munit.FunSuite {
       val t = Future { sleep(d.toMillis) }
       Try:
         Async.select(
-          t handle: _ =>
+          t.handle: _ =>
             throw TimeoutException(),
-          f handle: v =>
+          f.handle: v =>
             v.get
         )
 

--- a/shared/src/test/scala/TimerBehavior.scala
+++ b/shared/src/test/scala/TimerBehavior.scala
@@ -11,7 +11,7 @@ class TimerBehavior extends munit.FunSuite {
   import gears.async.default.given
 
   test("sleeping does sleep") {
-    Async.blocking:
+    Async.fromSync:
       val now1 = System.currentTimeMillis()
       sleep(200)
       val now2 = System.currentTimeMillis()
@@ -19,7 +19,7 @@ class TimerBehavior extends munit.FunSuite {
   }
 
   test("timer does sleep") {
-    Async.blocking:
+    Async.fromSync:
       val timer = Timer(1.second)
       Future { timer.run() }
       assert(timer.src.awaitResult == timer.TimerEvent.Tick)
@@ -39,7 +39,7 @@ class TimerBehavior extends munit.FunSuite {
 
   test("racing with a sleeping future") {
     var touched = false
-    Async.blocking:
+    Async.fromSync:
       val t = `cancel future after timeout`(
         250.millis,
         Future:

--- a/shared/src/test/scala/examples/CountdownLatch.scala
+++ b/shared/src/test/scala/examples/CountdownLatch.scala
@@ -1,4 +1,6 @@
-package gears.async
+package examples
+
+import gears.async.*
 
 import scala.collection.mutable
 
@@ -7,7 +9,7 @@ class CountdownLatch(private var count: Int) extends Async.OriginalSource[Unit]:
   val listeners = mutable.Set[Listener[Unit]]()
 
   override def poll(l: Listener[Unit]) =
-    if count == 0 then l.completeNow((), this)
+    if count == 0 then l.completeNow((), this) || true
     else false
 
   override def addListener(l: Listener[Unit]) = synchronized:


### PR DESCRIPTION
Currently using nightly Scala 3 for support for scala.js 1.19.
JSPI async/await is provided with a shim and manual transformation, until they gain compiler support.

- `Async.blocking` is not really available unless we have top-level `await` or assume an existing `js.async` scope.
  To remedy this, `Async.blocking` now requires an instanace of the sealed `Async.FromSync` trait, which can be
  provided (and is provided by default) on JVM and Native by initializing `FromSync.BlockingWithLocks` with
  `AsyncSupport` and `Scheduler` as before.

  Specifically, the `Async.blocking` function requires an instance of the `FromSync.Blocking` trait, which refines
  `FromSync` with the requirement that the return type when running an asynchronous block is `T`.
  This is not always possible on Scala.js for example, where the default `FromSync` instance given would return
  `scala.concurrent.Future[T]` instead.

  There are two ways to get around this and have a top-level program to run on all 3 platforms:

  1. Use `Async.fromSync`, which is the same as `Async.blocking` but without the `Output[T] = T` requirement.
     One has to be careful that on Scala.js, this would return a `Future[T]`, and the computation might have not
     completed by the time `fromSync` returns.
  1. To instead have the blocking behavior, assuming top-level `await` or an existing `js.async` scope, provide
     an instance of `FromSync.Blocking` with the `js.UnsafeJsAsyncFromSync` implementation.

     ```scala
     import gears.async.*

     given Async.FromSync.Blocking = js.UnsafeJsAsyncFromSync`
     ```

- Because of the single-threaded nature of JS, listener locks have to be able to suspend an asynchronous computation
  instead of blocking the whole thread as possible on JVM/Native. Therefore, `NumberedLock` on scala.js implicitly
  assumes top-level `await` or an existing `js.async` scope.

  This works nicely with `Future` and `Promise`s in Gears, as well as interacting directly with JavaScript promises,
  however manually written `Sources` should be aware of this limitation.

- Writing spinning-like code under a `Future` may directly block the entire computation. This is not a direct limitation
  on JS alone (this will also saturate a carrier thread on JVM/Native as well), but has a much more direct effect on
  scala.js due to only having a single thread.
