### PR TITLE
Node 26 and enable Scala.js stress tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         java-version: 21
     - uses: actions/setup-node@v4
       with:
-          node-version: '24'
+          node-version: '26'
     - uses: sbt/setup-sbt@v1
     - name: Test
       run: sbt rootJS/test

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An Experimental Asynchronous Programming Library for Scala 3. It aims to be:
 - **Cross-platform**: Works on JVM >= 21, Scala Native and Scala.js with WAsm support.
 
 > [!WARNING]  
-> Currently on V8 <14.2.75 (Node.js 24 and 25), there is a bug that causes stack overflows in nested async contexts, which are used extensively by Gears. Consider waiting for a later release, stay on Node.js 23, or use Deno / Bun / Firefox as the WAsm runtime target.
+> On V8 <14.2.75 (Node.js 24 and 25), there is a bug that causes stack overflows in nested async contexts, which are used extensively by Gears. Use Node.js 26+, or stay on Node.js 23, or use Deno / Bun / Firefox as the Wasm runtime target.
 > See #165 for more details.
 
 ## Getting Started

--- a/build.sbt
+++ b/build.sbt
@@ -62,15 +62,10 @@ lazy val root =
             .withArgs(
               List(
                 "--experimental-wasm-exnref", // always required
-                "--experimental-wasm-jspi", // required for js.async/js.await
-                "--experimental-wasm-imported-strings", // optional (good for performance)
-                // "--turboshaft-wasm" // optional, but significantly increases stability
                 "--stack-size=204800"
               )
             )
           new NodeJSEnv(config)
-        },
-        // Skip until Node.js 26+, see lampepfl/gears#165
-        Test / testOptions += Tests.Argument(MUnitFramework, "--exclude-tags=stress")
+        }
       )
     )

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
               libunwind
               zlib
               # Scala.js deps
-              nodejs_25
+              nodejs_26
               # Dev deps
               metals
               scalafix

--- a/js/src/main/scala/async/WasmJSPISuspend.scala
+++ b/js/src/main/scala/async/WasmJSPISuspend.scala
@@ -20,7 +20,7 @@ private[async] inline def async[T](body: AsyncToken ?=> T): js.Promise[T] = js.a
   * @note
   *   this assumes that the root context is **already** under `js.async`.
   */
-trait WasmJSPISuspend(using AsyncToken) extends SuspendSupport:
+trait WasmJSPISuspend(using AsyncToken) extends AsyncSupport:
   /** The label stores a Promise that should be resolved every time the context is suspended or is completed. Since
     * Promises are one-time resolvables, every resumption will "reset" the label, giving it a new Promise (see
     * [[WasmLabel.reset]]).
@@ -71,6 +71,12 @@ trait WasmJSPISuspend(using AsyncToken) extends SuspendSupport:
     val suspend = WasmSuspension[T, R](label, suspResolve)
     label.resolve(body(suspend))
     js.await(suspPromise)
+
+  override private[async] def scheduleBoundary(body: Label[Unit] ?=> Unit)(using s: Scheduler): Unit =
+    val label = WasmLabel[Unit]()
+    s.execute: () =>
+      body(using label)
+      label.resolve(())
 end WasmJSPISuspend
 
 /** Overrides [[AsyncOperations]] with JavaScript-specific operations. */
@@ -94,7 +100,7 @@ object JsAsyncScheduler extends Scheduler:
 /** An implementation of [[AsyncSupport]] where we assume a JSPI-enabled WebAssembly environment under a
   * single-threaded, event-loop driven JavaScript scheduler (as assumed by [[JsAsyncScheduler]]).
   */
-final class WasmAsyncSupport(using AsyncToken) extends AsyncSupport with WasmJSPISuspend:
+final class WasmAsyncSupport(using AsyncToken) extends WasmJSPISuspend:
   type Scheduler = JsAsyncScheduler.type
 
 /** A special root-level implementation of the [[Async]] context, that uses JSPI async/await on top-level to wait for

--- a/shared/src/test/scala/Stress.scala
+++ b/shared/src/test/scala/Stress.scala
@@ -13,24 +13,24 @@ class StressTest extends munit.FunSuite:
   override val munitTimeout: Duration = 10.minutes
 
   test("survives a stress test that hammers on creating futures".tag(stressTag)) {
-    val total = 200_000L
+    val total = 200_000
     Async.fromSync:
-      Seq[Long](1, 2, 4, 16, 10000).foreach: parallelism =>
+      Seq(1, 2, 4, 16, 10000).foreach: parallelism =>
         val k = AtomicInteger(0)
         def compute(using Async) =
           k.incrementAndGet()
-        val collector = MutableCollector((1L to parallelism).map(_ => Future { compute })*)
+        val collector = MutableCollector((1 to parallelism).map(_ => Future { compute })*)
         var sum = 0L
         for i <- parallelism + 1 to total do
           sum += collector.results.read().right.get.await
           collector += Future { compute }
-        for i <- 1L to parallelism do sum += collector.results.read().right.get.await
-        assertEquals(sum, total * (total + 1) / 2)
+        for i <- 1 to parallelism do sum += collector.results.read().right.get.await
+        assertEquals(sum, total.toLong * (total + 1) / 2)
   }
 
   test("survives a stress test that hammers on suspending".tag(stressTag)) {
-    val total = 100_000L
-    val parallelism = 5000L
+    val total = 100_000
+    val parallelism = 5000
     Async.fromSync:
       val sleepy =
         val timer = Timer(1.second)
@@ -40,11 +40,11 @@ class StressTest extends munit.FunSuite:
       def compute(using Async) =
         sleepy.awaitResult
         k.incrementAndGet()
-      val collector = MutableCollector((1L to parallelism).map(_ => Future { compute })*)
+      val collector = MutableCollector((1 to parallelism).map(_ => Future { compute })*)
       var sum = 0L
       for i <- parallelism + 1 to total do
         sum += collector.results.read().right.get.await
         collector += Future { compute }
-      for i <- 1L to parallelism do sum += collector.results.read().right.get.await
-      assertEquals(sum, total * (total + 1) / 2)
+      for i <- 1 to parallelism do sum += collector.results.read().right.get.await
+      assertEquals(sum, total.toLong * (total + 1) / 2)
   }


### PR DESCRIPTION
Update to Node 26 that updated to 14.6.202.33, that fixed V8 issue discussed in #165.

edit: now StressTest doesn't fail with stack overflow, but it is still extremely slow on V8 🤔  -> It looks like loop over Long generates `NumericRange[Long]` that takes so long. Using Integer instead, and now tests finishes approximately 6min. maybe worth investigating on scala-js side.